### PR TITLE
feat: add master-admin-only reassign major mentor feature

### DIFF
--- a/backend/src/controllers/admin.controller.js
+++ b/backend/src/controllers/admin.controller.js
@@ -798,17 +798,133 @@ const resetSummerTrainingSeats = asyncHandler(async (req, res) => {
     );
 });
 
+/**
+ * Get all professors (for admin dropdown when reassigning mentors)
+ */
+const getAllProfessors = asyncHandler(async (req, res) => {
+  const professors = await Professor.find(
+    {},
+    "fullName idNumber email currentCount limits"
+  ).sort({ fullName: 1 });
+
+  return res
+    .status(200)
+    .json(
+      new ApiResponse(200, professors, "All professors fetched successfully")
+    );
+});
+
+/**
+ * Reassign a major project group's mentor from one professor to another.
+ * Updates: Major group, old professor, new professor — all in a transaction.
+ */
+const reassignMajorMentor = asyncHandler(async (req, res) => {
+  const { groupId, newProfessorId } = req.body;
+
+  if (!groupId || !newProfessorId) {
+    throw new ApiError(400, "groupId and newProfessorId are required");
+  }
+
+  if (!mongoose.Types.ObjectId.isValid(newProfessorId)) {
+    throw new ApiError(400, "Invalid newProfessorId");
+  }
+
+  // Find the group by its 6-char groupId string
+  const group = await Major.findOne({ groupId }).populate("members");
+  if (!group) {
+    throw new ApiError(404, `Major group with ID "${groupId}" not found`);
+  }
+
+  const newProf = await Professor.findById(newProfessorId);
+  if (!newProf) {
+    throw new ApiError(404, "New professor not found");
+  }
+
+  // Check if already assigned to this professor
+  if (
+    group.majorAllocatedProf &&
+    group.majorAllocatedProf.toString() === newProfessorId
+  ) {
+    throw new ApiError(
+      409,
+      "This group is already assigned to the selected professor"
+    );
+  }
+
+  const numMembers = group.members.length;
+  const oldProfId = group.majorAllocatedProf;
+
+  // Start a transaction
+  const session = await mongoose.startSession();
+  session.startTransaction();
+
+  try {
+    // 1. Update the group's allocated professor
+    group.majorAllocatedProf = newProfessorId;
+    await group.save({ session, validateBeforeSave: false });
+
+    // 2. Remove from old professor (if one existed)
+    if (oldProfId) {
+      const oldProf = await Professor.findById(oldProfId).session(session);
+      if (oldProf) {
+        oldProf.students.major_project.pull(group._id);
+        oldProf.currentCount.major_project = Math.max(
+          0,
+          oldProf.currentCount.major_project - numMembers
+        );
+        await oldProf.save({ session });
+      }
+    }
+
+    // 3. Add to new professor
+    if (!newProf.students.major_project.includes(group._id)) {
+      newProf.students.major_project.push(group._id);
+    }
+    newProf.currentCount.major_project += numMembers;
+    await newProf.save({ session });
+
+    await session.commitTransaction();
+    session.endSession();
+
+    // Fetch updated group with populated data for the response
+    const updatedGroup = await Major.findById(group._id)
+      .populate("members", "fullName rollNumber email")
+      .populate("majorAllocatedProf", "fullName idNumber email")
+      .populate("org", "companyName");
+
+    return res
+      .status(200)
+      .json(
+        new ApiResponse(
+          200,
+          updatedGroup,
+          `Mentor successfully reassigned to ${newProf.fullName}`
+        )
+      );
+  } catch (error) {
+    await session.abortTransaction();
+    session.endSession();
+    console.error("Error reassigning mentor:", error);
+    throw new ApiError(
+      500,
+      "Something went wrong while reassigning mentor: " + error.message
+    );
+  }
+});
+
 export {
   createBatchAdmin,
   deleteAdmin,
   getAllAdmins,
   getAllMajorProjects,
   getAllMinorProjects,
+  getAllProfessors,
   getBatchStats,
   getCurrendAdmin,
   getUnverifiedUsers,
   loginAdmin,
   logoutAdmin,
+  reassignMajorMentor,
   registerAdmin,
   updateAdmin,
   verifyUser,

--- a/backend/src/routes/admin.routes.js
+++ b/backend/src/routes/admin.routes.js
@@ -5,11 +5,13 @@ import {
   getAllAdmins,
   getAllMajorProjects,
   getAllMinorProjects,
+  getAllProfessors,
   getBatchStats,
   getCurrendAdmin,
   getUnverifiedUsers,
   loginAdmin,
   logoutAdmin,
+  reassignMajorMentor,
   registerAdmin,
   rejectUser,
   updateAdmin,
@@ -71,5 +73,7 @@ router.route("/admins/create").post(verifyMasterAdmin, createBatchAdmin);
 router.route("/admins/:adminId").patch(verifyMasterAdmin, updateAdmin);
 router.route("/admins/:adminId").delete(verifyMasterAdmin, deleteAdmin);
 router.route("/reset-summer-seats").post(verifyMasterAdmin, resetSummerTrainingSeats);
+router.route("/get-all-professors").get(verifyMasterAdmin, getAllProfessors);
+router.route("/reassign-major-mentor").post(verifyMasterAdmin, reassignMajorMentor);
 
 export default router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -60,6 +60,7 @@ import GroupManagement from "./components/GroupManagement";
 import MajorGroupManagement from "./components/MajorGroupManagement";
 import MajorProject from "./components/MajorProject";
 import MajorProjectTable from "./components/MajorProjectTable";
+import ReassignMajorMentor from "./components/ReassignMajorMentor";
 import MasterAdminDashboard from "./components/MasterAdminDashboard";
 import MinorGroupManagement from "./components/MinorGroupManagement";
 import MinorProject from "./components/MinorProject";
@@ -187,6 +188,7 @@ export default function App() {
           <Route path="internship-table" element={<Internshiptable />} />
           <Route path="minor-project-table" element={<MinorProjectTable />} />
           <Route path="major-project-table" element={<MajorProjectTable />} />
+          <Route path="reassign-major-mentor" element={<ReassignMajorMentor />} />
           <Route path="admin-room-request" element={<AdminRoomRequests />} />
           <Route path="companies-table" element={<AdminAddCompanies />} />
           <Route path="assign-company" element={<CompanyAssignmentForm />} />

--- a/frontend/src/components/ReassignMajorMentor.jsx
+++ b/frontend/src/components/ReassignMajorMentor.jsx
@@ -1,0 +1,328 @@
+import axios from "axios";
+import { useEffect, useState } from "react";
+import { ToastContainer, toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+
+export default function ReassignMajorMentor() {
+  const [groupIdInput, setGroupIdInput] = useState("");
+  const [groupData, setGroupData] = useState(null);
+  const [professors, setProfessors] = useState([]);
+  const [selectedProfId, setSelectedProfId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [searching, setSearching] = useState(false);
+  const [profSearch, setProfSearch] = useState("");
+
+  // Fetch all professors on mount
+  useEffect(() => {
+    const fetchProfessors = async () => {
+      try {
+        const res = await axios.get("/api/v1/admin/get-all-professors");
+        setProfessors(res.data.data);
+      } catch (err) {
+        console.error("Error fetching professors:", err);
+        toast.error("Failed to load professors list");
+      }
+    };
+    fetchProfessors();
+  }, []);
+
+  // Search for a group by groupId
+  const handleSearch = async () => {
+    const trimmed = groupIdInput.trim().toUpperCase();
+    if (!trimmed) {
+      toast.warn("Please enter a Group ID");
+      return;
+    }
+
+    setSearching(true);
+    setGroupData(null);
+    setSelectedProfId("");
+
+    try {
+      // We use the existing major projects endpoint and filter client-side
+      // Try batch 22 first (the students in the Excel are batch 22)
+      const batches = [22, 23, 24, 25];
+      let found = null;
+
+      for (const batch of batches) {
+        try {
+          const res = await axios.get("/api/v1/admin/get-major-projects", {
+            params: { batch },
+          });
+          const records = res.data.data.response || [];
+          const match = records.find(
+            (r) => r.groupId?.toUpperCase() === trimmed,
+          );
+          if (match) {
+            // Get all members of this group
+            const groupMembers = records.filter(
+              (r) => r.groupId?.toUpperCase() === trimmed,
+            );
+            found = {
+              groupId: match.groupId,
+              type: match.type,
+              org: match.org,
+              projectTitle: match.projectTitle,
+              mentor: match.mentor,
+              members: groupMembers.map((r) => ({
+                rollNumber: r.student.rollNumber,
+                fullName: r.student.fullName,
+                email: r.student.email,
+                branch: r.student.branch,
+              })),
+            };
+            break;
+          }
+        } catch {
+          // Access denied for this batch, skip it
+        }
+      }
+
+      if (found) {
+        setGroupData(found);
+        toast.success(`Found group ${found.groupId}`);
+      } else {
+        toast.error(`No group found with ID "${trimmed}"`);
+      }
+    } catch (err) {
+      console.error("Error searching group:", err);
+      toast.error("Error searching for group");
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  // Reassign mentor
+  const handleReassign = async () => {
+    if (!groupData || !selectedProfId) {
+      toast.warn("Please select a professor first");
+      return;
+    }
+
+    const selectedProf = professors.find((p) => p._id === selectedProfId);
+    const confirmMsg = `Are you sure you want to reassign group ${groupData.groupId} to ${selectedProf?.fullName}?`;
+
+    if (!window.confirm(confirmMsg)) return;
+
+    setLoading(true);
+    try {
+      const res = await axios.post("/api/v1/admin/reassign-major-mentor", {
+        groupId: groupData.groupId,
+        newProfessorId: selectedProfId,
+      });
+
+      toast.success(res.data.message || "Mentor reassigned successfully!");
+
+      // Update the displayed data
+      const updated = res.data.data;
+      setGroupData((prev) => ({
+        ...prev,
+        mentor: updated.majorAllocatedProf
+          ? {
+              fullName: updated.majorAllocatedProf.fullName,
+              idNumber: updated.majorAllocatedProf.idNumber,
+            }
+          : null,
+      }));
+      setSelectedProfId("");
+
+      // Refresh professors list to get updated counts
+      const profRes = await axios.get("/api/v1/admin/get-all-professors");
+      setProfessors(profRes.data.data);
+    } catch (err) {
+      console.error("Error reassigning mentor:", err);
+      toast.error(
+        err.response?.data?.message || "Failed to reassign mentor",
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const filteredProfessors = professors.filter(
+    (p) =>
+      p.fullName?.toLowerCase().includes(profSearch.toLowerCase()) ||
+      p.idNumber?.toLowerCase().includes(profSearch.toLowerCase()),
+  );
+
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      <ToastContainer />
+      <h1 className="text-center text-3xl font-bold mb-8">
+        REASSIGN MAJOR PROJECT MENTOR
+      </h1>
+
+      {/* Search Section */}
+      <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+        <h2 className="text-lg font-semibold mb-4">
+          Step 1: Search Group by Group ID
+        </h2>
+        <div className="flex gap-3">
+          <input
+            type="text"
+            value={groupIdInput}
+            onChange={(e) => setGroupIdInput(e.target.value.toUpperCase())}
+            onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+            placeholder="Enter Group ID (e.g. 4QZJDD)"
+            className="flex-1 p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono text-lg tracking-wider"
+            maxLength={6}
+          />
+          <button
+            onClick={handleSearch}
+            disabled={searching}
+            className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400 font-medium transition-colors"
+          >
+            {searching ? "Searching..." : "Search"}
+          </button>
+        </div>
+      </div>
+
+      {/* Group Details Section */}
+      {groupData && (
+        <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+          <h2 className="text-lg font-semibold mb-4">
+            Group Details:{" "}
+            <span className="font-mono text-blue-600">
+              {groupData.groupId}
+            </span>
+          </h2>
+
+          <div className="grid grid-cols-2 gap-4 mb-4">
+            <div>
+              <span className="text-gray-500 text-sm">Type:</span>
+              <p className="font-medium capitalize">{groupData.type}</p>
+            </div>
+            <div>
+              <span className="text-gray-500 text-sm">Organisation:</span>
+              <p className="font-medium">{groupData.org || "N/A"}</p>
+            </div>
+            <div>
+              <span className="text-gray-500 text-sm">Project Title:</span>
+              <p className="font-medium">
+                {groupData.projectTitle || "Not set"}
+              </p>
+            </div>
+            <div>
+              <span className="text-gray-500 text-sm">Current Mentor:</span>
+              <p
+                className={`font-medium ${groupData.mentor ? "text-green-700" : "text-red-500"}`}
+              >
+                {groupData.mentor ? groupData.mentor.fullName : "Not assigned"}
+              </p>
+            </div>
+          </div>
+
+          <div>
+            <span className="text-gray-500 text-sm">Members:</span>
+            <table className="w-full mt-2 text-sm">
+              <thead>
+                <tr className="bg-gray-100">
+                  <th className="text-left px-3 py-2">Roll Number</th>
+                  <th className="text-left px-3 py-2">Name</th>
+                  <th className="text-left px-3 py-2">Email</th>
+                  <th className="text-left px-3 py-2">Branch</th>
+                </tr>
+              </thead>
+              <tbody>
+                {groupData.members.map((m, i) => (
+                  <tr key={i} className="border-b">
+                    <td className="px-3 py-2 font-mono">{m.rollNumber}</td>
+                    <td className="px-3 py-2 capitalize">{m.fullName}</td>
+                    <td className="px-3 py-2">{m.email}</td>
+                    <td className="px-3 py-2">{m.branch}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Reassign Section */}
+      {groupData && (
+        <div className="bg-white rounded-lg shadow-md p-6">
+          <h2 className="text-lg font-semibold mb-4">
+            Step 2: Select New Mentor
+          </h2>
+
+          <input
+            type="text"
+            value={profSearch}
+            onChange={(e) => setProfSearch(e.target.value)}
+            placeholder="Search professor by name or ID..."
+            className="w-full p-3 mb-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+
+          <select
+            value={selectedProfId}
+            onChange={(e) => setSelectedProfId(e.target.value)}
+            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mb-4"
+            size={Math.min(8, filteredProfessors.length + 1)}
+          >
+            <option value="">-- Select a Professor --</option>
+            {filteredProfessors.map((prof) => (
+              <option key={prof._id} value={prof._id}>
+                {prof.fullName} ({prof.idNumber}) — Major slots:{" "}
+                {prof.currentCount?.major_project || 0}/
+                {prof.limits?.major_project || 0}
+              </option>
+            ))}
+          </select>
+
+          {selectedProfId && (
+            <div className="bg-yellow-50 border border-yellow-300 rounded-lg p-4 mb-4">
+              <p className="text-sm text-yellow-800">
+                <strong>⚠️ Confirm:</strong> You are about to reassign group{" "}
+                <strong className="font-mono">{groupData.groupId}</strong>
+                {groupData.mentor && (
+                  <>
+                    {" "}
+                    from{" "}
+                    <strong className="text-red-600">
+                      {groupData.mentor.fullName}
+                    </strong>
+                  </>
+                )}{" "}
+                to{" "}
+                <strong className="text-green-700">
+                  {
+                    professors.find((p) => p._id === selectedProfId)
+                      ?.fullName
+                  }
+                </strong>
+                .
+              </p>
+            </div>
+          )}
+
+          <button
+            onClick={handleReassign}
+            disabled={loading || !selectedProfId}
+            className="w-full py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:bg-gray-400 font-semibold text-lg transition-colors"
+          >
+            {loading ? "Reassigning..." : "Reassign Mentor"}
+          </button>
+        </div>
+      )}
+
+      {/* Instructions */}
+      {!groupData && !searching && (
+        <div className="bg-gray-50 rounded-lg p-6 text-center text-gray-600">
+          <p className="text-lg mb-2">
+            Enter a Major Project Group ID above to get started.
+          </p>
+          <p className="text-sm">
+            You can find Group IDs in the{" "}
+            <a
+              href="/admin-db/major-project-table"
+              className="text-blue-600 underline"
+            >
+              Major Project Records
+            </a>{" "}
+            table.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/SideBarAdmin.jsx
+++ b/frontend/src/components/SideBarAdmin.jsx
@@ -177,12 +177,15 @@ export default function Sidebar() {
   }, []);
 
   // Add Manage Admins link for master admins
-  const finalLinks = isMasterAdmin 
+  const finalLinks = isMasterAdmin
     ? [...adminLinks, {
+        text: "Reassign Major Mentor",
+        icon: <HiArchive />,
+        to: "/admin-db/reassign-major-mentor",
+      }, {
         text: "Manage Admins",
         icon: <HiUser />,
         to: "/admin-db/manage-admins",
-        isMasterOnly: true,
       }]
     : adminLinks;
   // const [isAdmin, setIsAdmin] = useState(true);


### PR DESCRIPTION
## Summary
- Adds a new "Reassign Major Mentor" feature that allows master admins to reassign major project groups to different professors when mentors leave or need to be changed
- Restricts both the API endpoints (`/get-all-professors`, `/reassign-major-mentor`) and the sidebar link to master admin only using `verifyMasterAdmin` middleware
- Batch admins cannot see or access this feature

## Changes
- **Backend:** Added `getAllProfessors` and `reassignMajorMentor` controllers with transaction-safe database updates
- **Backend:** Added two new master-admin-only routes
- **Frontend:** Added `ReassignMajorMentor` component with group search and professor selection
- **Frontend:** Moved sidebar link behind master admin role check


<img width="1918" height="1015" alt="image" src="https://github.com/user-attachments/assets/17e5f520-8b11-45f4-ad08-a5d97d3434df" />
