### PR TITLE
Add admin user onboarding module with CSV import

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,6 +17,13 @@ CORS_ORIGIN=http://localhost:5173
 AUTH_EMAIL=your-email@gmail.com
 AUTH_PASSWORD=your-app-password
 
+# Admin user onboarding
+# Base URL used for the login link in welcome emails (falls back to CORS_ORIGIN)
+CLIENT_URL=http://localhost:5173
+# How many onboarding welcome emails the provider allows per rolling window
+ONBOARDING_MAIL_LIMIT=100
+ONBOARDING_MAIL_WINDOW_HOURS=24
+
 # Cloudinary (for file uploads)
 CLOUDINARY_CLOUD_NAME=your-cloud-name
 CLOUDINARY_API_KEY=your-api-key

--- a/backend/src/controllers/userImport.controller.js
+++ b/backend/src/controllers/userImport.controller.js
@@ -12,6 +12,16 @@ const MAX_ROWS = 500;
 /** How many welcome mails are dispatched concurrently. */
 const MAIL_CONCURRENCY = 5;
 
+/** How many accounts are written concurrently. */
+const CREATE_CONCURRENCY = 5;
+
+/**
+ * The mail provider caps how many messages we may send per rolling window.
+ * Both are configurable so ops can raise them without a code change.
+ */
+const MAIL_LIMIT = Number(process.env.ONBOARDING_MAIL_LIMIT || 100);
+const MAIL_WINDOW_HOURS = Number(process.env.ONBOARDING_MAIL_WINDOW_HOURS || 24);
+
 /** Users created here never upload an ID card, so a marker is stored instead. */
 const IMPORTED_ID_CARD = "admin-onboarded";
 
@@ -315,17 +325,51 @@ const runWithConcurrency = async (items, limit, worker) => {
 };
 
 /**
- * Create one student account and mail the credentials.
+ * How many welcome mails were sent inside the current rolling window, and how
+ * many the provider still allows. Only onboarding mails are counted - OTP and
+ * verification mails sent elsewhere are not visible here.
+ * @returns {Promise<{ limit: number, used: number, remaining: number, windowHours: number, resetsAt: Date|null }>}
+ */
+const getMailQuota = async () => {
+  const since = new Date(Date.now() - MAIL_WINDOW_HOURS * 60 * 60 * 1000);
+  const used = await User.countDocuments({
+    "onboarding.welcomeMailSentAt": { $gte: since },
+  });
+
+  // The window frees up again when the oldest send inside it ages out.
+  const oldest = await User.findOne({
+    "onboarding.welcomeMailSentAt": { $gte: since },
+  })
+    .sort({ "onboarding.welcomeMailSentAt": 1 })
+    .select("onboarding.welcomeMailSentAt");
+
+  const oldestSentAt = oldest?.onboarding?.welcomeMailSentAt || null;
+
+  return {
+    limit: MAIL_LIMIT,
+    used,
+    remaining: Math.max(0, MAIL_LIMIT - used),
+    windowHours: MAIL_WINDOW_HOURS,
+    resetsAt: oldestSentAt
+      ? new Date(oldestSentAt.getTime() + MAIL_WINDOW_HOURS * 60 * 60 * 1000)
+      : null,
+  };
+};
+
+/**
+ * Create one student account, queued for a welcome mail.
+ * No mail is sent here - see sendWelcomeMailToUser.
  * @param {Record<string, any>} data
  * @param {boolean} autoVerify
- * @param {boolean} sendEmail
+ * @param {string} [adminId]
+ * @returns {Promise<import("mongoose").Document>}
  */
-const createUserAndNotify = async (data, autoVerify, sendEmail) => {
-  const password = generatePassword();
-
-  const user = await User.create({
+const createUser = async (data, autoVerify, adminId) =>
+  User.create({
     username: data.username,
-    password,
+    // Replaced by a freshly generated one the moment the welcome mail goes
+    // out, so no password we have ever shown anybody is left sitting here.
+    password: generatePassword(),
     fullName: data.fullName,
     rollNumber: data.rollNumber,
     email: data.email,
@@ -335,20 +379,65 @@ const createUserAndNotify = async (data, autoVerify, sendEmail) => {
     batch: data.batch,
     idCard: IMPORTED_ID_CARD,
     isVerified: Boolean(autoVerify),
+    onboarding: {
+      isAdminOnboarded: true,
+      welcomeMailStatus: "pending",
+      onboardedAt: new Date(),
+      onboardedBy: adminId || null,
+    },
   });
 
-  let mail = { sent: false, error: "email sending was skipped" };
-  if (sendEmail) {
-    const { subject, html } = buildWelcomeEmail({
-      fullName: data.fullName,
-      username: data.username,
-      email: data.email,
-      password,
-    });
-    mail = await sendMail({ to: data.email, subject, html });
-  }
+/**
+ * Rotate the account's password and mail the new credentials.
+ *
+ * The password is generated at send time rather than at creation time so no
+ * plaintext password is ever stored while an account waits in the queue. The
+ * rotation is saved *before* the mail goes out, so a crash mid-send can only
+ * leave an undelivered password behind - never a delivered one that doesn't
+ * work. Retrying simply rotates again, which is safe because the account has
+ * not been used yet.
+ *
+ * @param {import("mongoose").Document} user
+ * @returns {Promise<{ sent: boolean, error?: string }>}
+ */
+const sendWelcomeMailToUser = async (user) => {
+  const password = generatePassword();
 
-  return { userId: user._id, mail };
+  user.password = password; // hashed by the schema's pre-save hook
+  user.onboarding.welcomeMailAttempts =
+    (user.onboarding.welcomeMailAttempts || 0) + 1;
+  await user.save({ validateBeforeSave: false });
+
+  const { subject, html } = buildWelcomeEmail({
+    fullName: user.fullName,
+    username: user.username,
+    email: user.email,
+    password,
+  });
+  const mail = await sendMail({ to: user.email, subject, html });
+
+  if (mail.sent) {
+    user.onboarding.welcomeMailStatus = "sent";
+    user.onboarding.welcomeMailSentAt = new Date();
+    user.onboarding.welcomeMailError = "";
+  } else {
+    user.onboarding.welcomeMailStatus = "failed";
+    user.onboarding.welcomeMailError = mail.error || "unknown error";
+  }
+  await user.save({ validateBeforeSave: false });
+
+  return mail;
+};
+
+/**
+ * Restrict a query to the batches a non-master admin may act on.
+ * @param {object} admin
+ * @param {object} filter
+ * @returns {object}
+ */
+const scopeToAdminBatches = (admin, filter) => {
+  if (!admin || admin.role === "master") return filter;
+  return { ...filter, batch: { $in: admin.assignedBatches || [] } };
 };
 
 /**
@@ -414,8 +503,13 @@ const previewUserImport = asyncHandler(async (req, res) => {
 
 /**
  * POST /api/v1/admin/user-import/import
- * Creates every valid row and mails the generated credentials.
- * Invalid rows are skipped and reported back rather than failing the request.
+ *
+ * Creates every valid row. Accounts are always created - mailing is a separate,
+ * quota-bounded step. If the admin asked to mail immediately, as many of the
+ * new accounts as the remaining quota allows are mailed now (optionally capped
+ * further by mailLimit); the rest stay queued and can be sent later from the
+ * pending list. Invalid rows are skipped and reported rather than failing the
+ * request.
  */
 const importUsersFromCSV = asyncHandler(async (req, res) => {
   if (!req.file?.buffer) {
@@ -424,6 +518,17 @@ const importUsersFromCSV = asyncHandler(async (req, res) => {
 
   const autoVerify = req.body.autoVerify !== "false";
   const sendEmail = req.body.sendEmail !== "false";
+  const requestedMailLimit =
+    req.body.mailLimit === undefined || req.body.mailLimit === ""
+      ? null
+      : Number(req.body.mailLimit);
+
+  if (
+    requestedMailLimit !== null &&
+    (Number.isNaN(requestedMailLimit) || requestedMailLimit < 0)
+  ) {
+    throw new ApiError(400, "mailLimit must be a non-negative number");
+  }
 
   const { rows } = await analyseCsv(req.file.buffer.toString("utf-8"), req.admin);
 
@@ -434,25 +539,51 @@ const importUsersFromCSV = asyncHandler(async (req, res) => {
     email: row.data.email,
     batch: row.data.batch,
     status: row.status === "ready" ? "pending" : "skipped",
+    mailStatus: row.status === "ready" ? "queued" : "not_created",
     mailSent: false,
     message: row.errors.join("; "),
   }));
 
-  const pending = results.filter((r) => r.status === "pending");
+  const toCreate = results.filter((r) => r.status === "pending");
+  const created = [];
 
-  await runWithConcurrency(pending, MAIL_CONCURRENCY, async (result) => {
+  await runWithConcurrency(toCreate, CREATE_CONCURRENCY, async (result) => {
     const row = rows.find((r) => r.rowNumber === result.rowNumber);
     try {
-      const { mail } = await createUserAndNotify(row.data, autoVerify, sendEmail);
+      const user = await createUser(row.data, autoVerify, req.admin?._id);
       result.status = "created";
-      result.mailSent = mail.sent;
-      result.message = mail.sent
-        ? "Account created and credentials emailed"
-        : `Account created, but the email failed: ${mail.error}`;
+      result.userId = user._id;
+      result.message = "Account created, welcome email queued";
+      created.push({ result, user });
     } catch (error) {
       result.status = "failed";
+      result.mailStatus = "not_created";
       result.message = error?.message || "Failed to create the account";
     }
+  });
+
+  // Mail phase: bounded by the provider quota, in CSV order so the admin can
+  // predict who gets contacted first.
+  const quotaBefore = await getMailQuota();
+  let mailBudget = 0;
+  if (sendEmail) {
+    mailBudget = Math.min(
+      quotaBefore.remaining,
+      requestedMailLimit === null ? Infinity : requestedMailLimit
+    );
+  }
+
+  const toMail = created
+    .sort((a, b) => a.result.rowNumber - b.result.rowNumber)
+    .slice(0, mailBudget);
+
+  await runWithConcurrency(toMail, MAIL_CONCURRENCY, async ({ result, user }) => {
+    const mail = await sendWelcomeMailToUser(user);
+    result.mailSent = mail.sent;
+    result.mailStatus = mail.sent ? "sent" : "failed";
+    result.message = mail.sent
+      ? "Account created and credentials emailed"
+      : `Account created, but the email failed: ${mail.error}`;
   });
 
   const summary = {
@@ -461,18 +592,227 @@ const importUsersFromCSV = asyncHandler(async (req, res) => {
     skipped: results.filter((r) => r.status === "skipped").length,
     failed: results.filter((r) => r.status === "failed").length,
     mailsSent: results.filter((r) => r.mailSent).length,
+    mailsFailed: results.filter((r) => r.mailStatus === "failed").length,
+    stillQueued: results.filter((r) => r.mailStatus === "queued").length,
   };
-  summary.mailsFailed = summary.created - summary.mailsSent;
+
+  const quota = await getMailQuota();
+
+  let message = `${summary.created} of ${summary.total} account(s) created`;
+  if (summary.stillQueued > 0) {
+    message += `; ${summary.stillQueued} welcome email(s) queued for a later batch`;
+  }
 
   return res
     .status(200)
     .json(
       new ApiResponse(
         200,
-        { fileName: req.file.originalname, summary, results },
-        `${summary.created} of ${summary.total} account(s) created`
+        { fileName: req.file.originalname, summary, results, quota },
+        message
       )
     );
+});
+
+/**
+ * GET /api/v1/admin/user-import/pending
+ *
+ * The welcome-mail queue: accounts that exist but have not been mailed yet
+ * (or whose mail failed), plus the current provider quota. Batch admins only
+ * ever see their own batches.
+ *
+ * Query: status=pending|failed|sent|all, batch, search, page, limit
+ */
+const listPendingWelcomeMails = asyncHandler(async (req, res) => {
+  const status = req.query.status || "unsent";
+  const page = Math.max(1, Number(req.query.page) || 1);
+  const limit = Math.min(200, Math.max(1, Number(req.query.limit) || 50));
+
+  const statusFilter =
+    status === "all"
+      ? { $in: ["pending", "failed", "sent"] }
+      : status === "unsent"
+        ? { $in: ["pending", "failed"] }
+        : status;
+
+  let filter = scopeToAdminBatches(req.admin, {
+    "onboarding.welcomeMailStatus": statusFilter,
+  });
+
+  if (req.query.batch) {
+    const batch = parseBatch(req.query.batch);
+    if (batch === null) {
+      throw new ApiError(400, "batch must look like 22, K22 or 2022");
+    }
+    const permissionError = batchPermissionError(req.admin, batch);
+    if (permissionError) throw new ApiError(403, permissionError);
+    filter.batch = batch;
+  }
+
+  if (req.query.search) {
+    const term = String(req.query.search).trim();
+    // Escaped so a stray "(" in the search box can't throw a regex error.
+    const safe = term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    filter.$or = [
+      { fullName: { $regex: safe, $options: "i" } },
+      { rollNumber: { $regex: safe, $options: "i" } },
+      { email: { $regex: safe, $options: "i" } },
+    ];
+  }
+
+  const [users, total, quota] = await Promise.all([
+    User.find(filter)
+      .select("fullName rollNumber email batch branch section isVerified onboarding createdAt")
+      .sort({ createdAt: 1 })
+      .skip((page - 1) * limit)
+      .limit(limit),
+    User.countDocuments(filter),
+    getMailQuota(),
+  ]);
+
+  const countsBase = scopeToAdminBatches(req.admin, {});
+  const [pendingCount, failedCount, sentCount] = await Promise.all([
+    User.countDocuments({ ...countsBase, "onboarding.welcomeMailStatus": "pending" }),
+    User.countDocuments({ ...countsBase, "onboarding.welcomeMailStatus": "failed" }),
+    User.countDocuments({ ...countsBase, "onboarding.welcomeMailStatus": "sent" }),
+  ]);
+
+  return res.status(200).json(
+    new ApiResponse(
+      200,
+      {
+        users,
+        pagination: { page, limit, total, pages: Math.ceil(total / limit) },
+        counts: {
+          pending: pendingCount,
+          failed: failedCount,
+          sent: sentCount,
+          unsent: pendingCount + failedCount,
+        },
+        quota,
+      },
+      "Welcome mail queue fetched"
+    )
+  );
+});
+
+/**
+ * POST /api/v1/admin/user-import/send-mails
+ *
+ * Sends welcome mails to an explicit set of users, or to the next N in the
+ * queue (oldest first). Never exceeds the provider quota - the request is
+ * trimmed to what is left in the window and the response says how many were
+ * dropped. Each successful send flips the account to "sent" so it drops out
+ * of the queue and is never mailed twice.
+ *
+ * Body: { userIds?: string[], count?: number, includeFailed?: boolean }
+ */
+const sendWelcomeMails = asyncHandler(async (req, res) => {
+  const { userIds, count, includeFailed = true } = req.body;
+
+  const eligibleStatuses = includeFailed ? ["pending", "failed"] : ["pending"];
+  const quota = await getMailQuota();
+
+  if (quota.remaining <= 0) {
+    throw new ApiError(
+      429,
+      `The ${quota.windowHours}h email quota of ${quota.limit} is used up. ${
+        quota.resetsAt
+          ? `Capacity frees up from ${quota.resetsAt.toISOString()}.`
+          : ""
+      }`
+    );
+  }
+
+  let targets;
+  if (Array.isArray(userIds) && userIds.length > 0) {
+    targets = await User.find(
+      scopeToAdminBatches(req.admin, {
+        _id: { $in: userIds },
+        "onboarding.welcomeMailStatus": { $in: eligibleStatuses },
+      })
+    ).sort({ createdAt: 1 });
+  } else {
+    const requested = Number(count);
+    if (!requested || Number.isNaN(requested) || requested < 1) {
+      throw new ApiError(
+        400,
+        "Provide either userIds or a positive count of users to mail"
+      );
+    }
+    targets = await User.find(
+      scopeToAdminBatches(req.admin, {
+        "onboarding.welcomeMailStatus": { $in: eligibleStatuses },
+      })
+    )
+      .sort({ createdAt: 1 })
+      .limit(Math.min(requested, quota.remaining));
+  }
+
+  if (targets.length === 0) {
+    throw new ApiError(
+      404,
+      "No matching accounts are waiting for a welcome email"
+    );
+  }
+
+  const selected = targets.slice(0, quota.remaining);
+  const droppedForQuota = targets.length - selected.length;
+
+  const results = selected.map((user) => ({
+    userId: user._id,
+    rollNumber: user.rollNumber,
+    fullName: user.fullName,
+    email: user.email,
+    batch: user.batch,
+    status: "pending",
+    message: "",
+  }));
+
+  await runWithConcurrency(selected, MAIL_CONCURRENCY, async (user) => {
+    const result = results.find(
+      (r) => r.userId.toString() === user._id.toString()
+    );
+    try {
+      const mail = await sendWelcomeMailToUser(user);
+      result.status = mail.sent ? "sent" : "failed";
+      result.message = mail.sent
+        ? "Credentials emailed"
+        : `Email failed: ${mail.error}`;
+    } catch (error) {
+      result.status = "failed";
+      result.message = error?.message || "Failed to send the email";
+    }
+  });
+
+  const summary = {
+    attempted: results.length,
+    sent: results.filter((r) => r.status === "sent").length,
+    failed: results.filter((r) => r.status === "failed").length,
+    droppedForQuota,
+  };
+
+  const quotaAfter = await getMailQuota();
+
+  let message = `${summary.sent} welcome email(s) sent`;
+  if (droppedForQuota > 0) {
+    message += `; ${droppedForQuota} left queued because the ${quota.windowHours}h quota of ${quota.limit} was reached`;
+  }
+
+  return res
+    .status(200)
+    .json(new ApiResponse(200, { summary, results, quota: quotaAfter }, message));
+});
+
+/**
+ * GET /api/v1/admin/user-import/quota
+ * Just the current mail allowance, for polling the UI banner.
+ */
+const getMailQuotaStatus = asyncHandler(async (req, res) => {
+  const quota = await getMailQuota();
+  return res
+    .status(200)
+    .json(new ApiResponse(200, quota, "Mail quota fetched"));
 });
 
 /**
@@ -521,32 +861,54 @@ const registerUserByAdmin = asyncHandler(async (req, res) => {
   const autoVerify = req.body.autoVerify !== false && req.body.autoVerify !== "false";
   const sendEmail = req.body.sendEmail !== false && req.body.sendEmail !== "false";
 
-  const { userId, mail } = await createUserAndNotify(data, autoVerify, sendEmail);
+  const user = await createUser(data, autoVerify, req.admin?._id);
+
+  // A single account still respects the quota; if there is no room it simply
+  // stays queued instead of failing the creation.
+  const quotaBefore = await getMailQuota();
+  let mail = { sent: false, error: null };
+  let mailStatus = "queued";
+
+  if (sendEmail && quotaBefore.remaining > 0) {
+    mail = await sendWelcomeMailToUser(user);
+    mailStatus = mail.sent ? "sent" : "failed";
+  } else if (sendEmail) {
+    mail.error = `the ${quotaBefore.windowHours}h email quota of ${quotaBefore.limit} is used up`;
+  }
+
+  const messages = {
+    sent: "Account created and credentials emailed",
+    failed: `Account created, but the email failed: ${mail.error}`,
+    queued: sendEmail
+      ? `Account created and queued - ${mail.error}. Send it from the Welcome Emails tab once quota frees up.`
+      : "Account created, welcome email queued",
+  };
 
   return res.status(201).json(
     new ApiResponse(
       201,
       {
-        userId,
+        userId: user._id,
         rollNumber: data.rollNumber,
         email: data.email,
         batch: data.batch,
         isVerified: autoVerify,
+        mailStatus,
         mailSent: mail.sent,
         mailError: mail.sent ? null : mail.error,
+        quota: await getMailQuota(),
       },
-      mail.sent
-        ? "Account created and credentials emailed"
-        : sendEmail
-          ? `Account created, but the email failed: ${mail.error}`
-          : "Account created"
+      messages[mailStatus]
     )
   );
 });
 
 export {
   downloadUserImportTemplate,
+  getMailQuotaStatus,
   importUsersFromCSV,
+  listPendingWelcomeMails,
   previewUserImport,
   registerUserByAdmin,
+  sendWelcomeMails,
 };

--- a/backend/src/controllers/userImport.controller.js
+++ b/backend/src/controllers/userImport.controller.js
@@ -1,0 +1,552 @@
+import crypto from "crypto";
+import { User } from "../models/user.model.js";
+import { ApiError } from "../utils/ApiError.js";
+import { ApiResponse } from "../utils/ApiResponse.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
+import { parseCSV, toCSV } from "../utils/csv.js";
+import { buildWelcomeEmail, sendMail } from "../utils/mailer.js";
+
+/** Hard cap so a single request can't fan out into thousands of mails. */
+const MAX_ROWS = 500;
+
+/** How many welcome mails are dispatched concurrently. */
+const MAIL_CONCURRENCY = 5;
+
+/** Users created here never upload an ID card, so a marker is stored instead. */
+const IMPORTED_ID_CARD = "admin-onboarded";
+
+/** Canonical CSV columns, in template order. */
+const TEMPLATE_HEADERS = [
+  "rollNumber",
+  "fullName",
+  "email",
+  "batch",
+  "branch",
+  "section",
+  "mobileNumber",
+  "username",
+];
+
+/** Accepted header spellings mapped onto the canonical field names. */
+const HEADER_ALIASES = {
+  rollnumber: "rollNumber",
+  rollno: "rollNumber",
+  roll: "rollNumber",
+  "roll number": "rollNumber",
+  roll_number: "rollNumber",
+  fullname: "fullName",
+  name: "fullName",
+  "full name": "fullName",
+  full_name: "fullName",
+  studentname: "fullName",
+  email: "email",
+  emailid: "email",
+  "email id": "email",
+  email_id: "email",
+  mail: "email",
+  batch: "batch",
+  year: "batch",
+  branch: "branch",
+  department: "branch",
+  dept: "branch",
+  section: "section",
+  sec: "section",
+  mobilenumber: "mobileNumber",
+  mobile: "mobileNumber",
+  "mobile number": "mobileNumber",
+  mobile_number: "mobileNumber",
+  phone: "mobileNumber",
+  contact: "mobileNumber",
+  username: "username",
+  userid: "username",
+};
+
+/**
+ * Map a raw CSV row onto canonical field names.
+ * @param {Record<string,string>} values
+ * @returns {Record<string,string>}
+ */
+const normalizeRow = (values) => {
+  const normalized = {};
+  Object.entries(values).forEach(([rawKey, rawValue]) => {
+    const key = HEADER_ALIASES[rawKey.trim().toLowerCase()];
+    if (key && normalized[key] === undefined) {
+      normalized[key] = (rawValue ?? "").trim();
+    }
+  });
+  return normalized;
+};
+
+/**
+ * Accepts 22, "22", "K22" or "2022" and returns the two digit batch number
+ * this app stores (22 for K22).
+ * @param {string|number} raw
+ * @returns {number|null}
+ */
+const parseBatch = (raw) => {
+  if (raw === undefined || raw === null || String(raw).trim() === "") {
+    return null;
+  }
+  const digits = String(raw).trim().replace(/^[kK]/, "");
+  if (!/^\d+$/.test(digits)) return null;
+  const value = Number(digits);
+  if (value >= 1900 && value <= 2999) return value % 100;
+  if (value >= 0 && value <= 99) return value;
+  return null;
+};
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const PASSWORD_ALPHABET = "abcdefghjkmnpqrstuvwxyzABCDEFGHJKMNPQRSTUVWXYZ23456789";
+
+/**
+ * Random, human-typeable temporary password.
+ * @returns {string}
+ */
+const generatePassword = (length = 10) => {
+  let password = "";
+  for (let i = 0; i < length; i++) {
+    password += PASSWORD_ALPHABET[crypto.randomInt(PASSWORD_ALPHABET.length)];
+  }
+  return password;
+};
+
+/**
+ * Validate and clean a single candidate record.
+ * @param {Record<string,string>} raw
+ * @returns {{ data: Record<string, any>, errors: string[] }}
+ */
+const validateRecord = (raw) => {
+  const errors = [];
+
+  const rollNumber = (raw.rollNumber || "").trim();
+  const fullName = (raw.fullName || "").trim();
+  const email = (raw.email || "").trim().toLowerCase();
+  const batch = parseBatch(raw.batch);
+  const branch = (raw.branch || "").trim();
+  const section = (raw.section || "").trim();
+  const mobileNumber = (raw.mobileNumber || "").replace(/[\s-]/g, "");
+  // The model expects "roll number in small case without special chars",
+  // so an omitted username is derived that way from the roll number.
+  const username = (raw.username || "").trim()
+    ? raw.username.trim().toLowerCase()
+    : rollNumber.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+  if (!rollNumber) errors.push("rollNumber is required");
+  if (!fullName) errors.push("fullName is required");
+  if (!email) {
+    errors.push("email is required");
+  } else if (!EMAIL_REGEX.test(email)) {
+    errors.push("email is not a valid address");
+  }
+  if (batch === null) {
+    errors.push("batch is required and must look like 22, K22 or 2022");
+  }
+  if (mobileNumber && !/^\d{10}$/.test(mobileNumber)) {
+    errors.push("mobileNumber must be exactly 10 digits");
+  }
+  if (rollNumber && !username) {
+    errors.push(
+      "username could not be derived from the roll number; add a username column"
+    );
+  } else if (username && !/^[a-z0-9._-]+$/.test(username)) {
+    errors.push(
+      "username may only contain letters, digits, dot, underscore or hyphen"
+    );
+  }
+
+  return {
+    data: {
+      rollNumber,
+      fullName,
+      email,
+      batch,
+      branch,
+      section,
+      username,
+      ...(mobileNumber ? { mobileNumber } : {}),
+    },
+    errors,
+  };
+};
+
+/**
+ * Batch admins may only onboard students into the batches assigned to them.
+ * @param {object} admin
+ * @param {number|null} batch
+ * @returns {string|null} error message, or null when allowed
+ */
+const batchPermissionError = (admin, batch) => {
+  if (!admin || admin.role === "master") return null;
+  if (batch === null || batch === undefined) return null;
+  if (!admin.assignedBatches?.length) {
+    return "You have no batches assigned, so you cannot onboard students";
+  }
+  if (!admin.assignedBatches.includes(Number(batch))) {
+    return `You don't have access to batch K${batch}`;
+  }
+  return null;
+};
+
+/**
+ * Turn CSV text into per-row records annotated with validation status and
+ * conflicts against both the file itself and the database.
+ * @param {string} csvText
+ * @param {object} admin
+ * @returns {Promise<{ rows: Array<object>, summary: object }>}
+ */
+const analyseCsv = async (csvText, admin) => {
+  const { headers, rows: rawRows } = parseCSV(csvText);
+
+  if (rawRows.length === 0) {
+    throw new ApiError(400, "The CSV file has no data rows");
+  }
+  if (rawRows.length > MAX_ROWS) {
+    throw new ApiError(
+      400,
+      `The CSV has ${rawRows.length} rows; please split it into files of at most ${MAX_ROWS} rows`
+    );
+  }
+
+  const recognised = headers
+    .map((h) => HEADER_ALIASES[h.trim().toLowerCase()])
+    .filter(Boolean);
+  const missing = ["rollNumber", "fullName", "email", "batch"].filter(
+    (field) => !recognised.includes(field)
+  );
+  if (missing.length) {
+    throw new ApiError(
+      400,
+      `CSV is missing required column(s): ${missing.join(", ")}. Download the template for the expected format.`
+    );
+  }
+
+  const rows = rawRows.map((row, index) => {
+    const { data, errors } = validateRecord(normalizeRow(row.values));
+    return {
+      rowNumber: index + 1,
+      lineNumber: row.lineNumber,
+      data,
+      errors,
+    };
+  });
+
+  // Conflicts inside the uploaded file itself.
+  const seen = { email: new Map(), rollNumber: new Map(), username: new Map() };
+  rows.forEach((row) => {
+    ["email", "rollNumber", "username"].forEach((field) => {
+      const value = row.data[field];
+      if (!value) return;
+      const key = value.toLowerCase();
+      if (seen[field].has(key)) {
+        row.errors.push(
+          `duplicate ${field} "${value}" (also on row ${seen[field].get(key)})`
+        );
+      } else {
+        seen[field].set(key, row.rowNumber);
+      }
+    });
+  });
+
+  // Batch permissions.
+  rows.forEach((row) => {
+    const permissionError = batchPermissionError(admin, row.data.batch);
+    if (permissionError) row.errors.push(permissionError);
+  });
+
+  // Conflicts against existing accounts.
+  const emails = rows.map((r) => r.data.email).filter(Boolean);
+  const rollNumbers = rows.map((r) => r.data.rollNumber).filter(Boolean);
+  const usernames = rows.map((r) => r.data.username).filter(Boolean);
+
+  const existing = await User.find({
+    $or: [
+      { email: { $in: emails } },
+      { rollNumber: { $in: rollNumbers } },
+      { username: { $in: usernames } },
+    ],
+  }).select("email rollNumber username");
+
+  const existingEmails = new Set(existing.map((u) => u.email?.toLowerCase()));
+  const existingRolls = new Set(existing.map((u) => u.rollNumber?.toLowerCase()));
+  const existingUsernames = new Set(existing.map((u) => u.username?.toLowerCase()));
+
+  rows.forEach((row) => {
+    if (existingEmails.has(row.data.email)) {
+      row.errors.push("an account with this email already exists");
+    }
+    if (existingRolls.has(row.data.rollNumber?.toLowerCase())) {
+      row.errors.push("an account with this roll number already exists");
+    }
+    if (existingUsernames.has(row.data.username)) {
+      row.errors.push("an account with this username already exists");
+    }
+  });
+
+  rows.forEach((row) => {
+    row.status = row.errors.length ? "invalid" : "ready";
+  });
+
+  return {
+    rows,
+    summary: {
+      total: rows.length,
+      ready: rows.filter((r) => r.status === "ready").length,
+      invalid: rows.filter((r) => r.status === "invalid").length,
+    },
+  };
+};
+
+/**
+ * Run an async worker over items with a bounded concurrency.
+ * @param {Array} items
+ * @param {number} limit
+ * @param {(item: any) => Promise<any>} worker
+ */
+const runWithConcurrency = async (items, limit, worker) => {
+  let cursor = 0;
+  const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (cursor < items.length) {
+      const index = cursor++;
+      await worker(items[index]);
+    }
+  });
+  await Promise.all(runners);
+};
+
+/**
+ * Create one student account and mail the credentials.
+ * @param {Record<string, any>} data
+ * @param {boolean} autoVerify
+ * @param {boolean} sendEmail
+ */
+const createUserAndNotify = async (data, autoVerify, sendEmail) => {
+  const password = generatePassword();
+
+  const user = await User.create({
+    username: data.username,
+    password,
+    fullName: data.fullName,
+    rollNumber: data.rollNumber,
+    email: data.email,
+    branch: data.branch || "",
+    section: data.section || "",
+    ...(data.mobileNumber ? { mobileNumber: data.mobileNumber } : {}),
+    batch: data.batch,
+    idCard: IMPORTED_ID_CARD,
+    isVerified: Boolean(autoVerify),
+  });
+
+  let mail = { sent: false, error: "email sending was skipped" };
+  if (sendEmail) {
+    const { subject, html } = buildWelcomeEmail({
+      fullName: data.fullName,
+      username: data.username,
+      email: data.email,
+      password,
+    });
+    mail = await sendMail({ to: data.email, subject, html });
+  }
+
+  return { userId: user._id, mail };
+};
+
+/**
+ * GET /api/v1/admin/user-import/template
+ * Downloads a ready-to-fill CSV template.
+ */
+const downloadUserImportTemplate = asyncHandler(async (req, res) => {
+  const sample = [
+    {
+      rollNumber: "BTECH/10001/22",
+      fullName: "Asha Verma",
+      email: "asha.verma@example.com",
+      batch: "22",
+      branch: "CSE",
+      section: "A",
+      mobileNumber: "9876543210",
+      username: "btech1000122",
+    },
+    {
+      rollNumber: "BTECH/10002/22",
+      fullName: "Rahul Nair",
+      email: "rahul.nair@example.com",
+      batch: "K22",
+      branch: "ECE",
+      section: "B",
+      mobileNumber: "",
+      username: "",
+    },
+  ];
+
+  res.setHeader("Content-Type", "text/csv; charset=utf-8");
+  res.setHeader(
+    "Content-Disposition",
+    'attachment; filename="user-import-template.csv"'
+  );
+  return res.status(200).send(toCSV(TEMPLATE_HEADERS, sample));
+});
+
+/**
+ * POST /api/v1/admin/user-import/preview
+ * Dry run: validates the CSV without touching the database.
+ */
+const previewUserImport = asyncHandler(async (req, res) => {
+  if (!req.file?.buffer) {
+    throw new ApiError(400, "A CSV file is required");
+  }
+
+  const { rows, summary } = await analyseCsv(
+    req.file.buffer.toString("utf-8"),
+    req.admin
+  );
+
+  return res
+    .status(200)
+    .json(
+      new ApiResponse(
+        200,
+        { fileName: req.file.originalname, summary, rows },
+        "CSV parsed successfully"
+      )
+    );
+});
+
+/**
+ * POST /api/v1/admin/user-import/import
+ * Creates every valid row and mails the generated credentials.
+ * Invalid rows are skipped and reported back rather than failing the request.
+ */
+const importUsersFromCSV = asyncHandler(async (req, res) => {
+  if (!req.file?.buffer) {
+    throw new ApiError(400, "A CSV file is required");
+  }
+
+  const autoVerify = req.body.autoVerify !== "false";
+  const sendEmail = req.body.sendEmail !== "false";
+
+  const { rows } = await analyseCsv(req.file.buffer.toString("utf-8"), req.admin);
+
+  const results = rows.map((row) => ({
+    rowNumber: row.rowNumber,
+    rollNumber: row.data.rollNumber,
+    fullName: row.data.fullName,
+    email: row.data.email,
+    batch: row.data.batch,
+    status: row.status === "ready" ? "pending" : "skipped",
+    mailSent: false,
+    message: row.errors.join("; "),
+  }));
+
+  const pending = results.filter((r) => r.status === "pending");
+
+  await runWithConcurrency(pending, MAIL_CONCURRENCY, async (result) => {
+    const row = rows.find((r) => r.rowNumber === result.rowNumber);
+    try {
+      const { mail } = await createUserAndNotify(row.data, autoVerify, sendEmail);
+      result.status = "created";
+      result.mailSent = mail.sent;
+      result.message = mail.sent
+        ? "Account created and credentials emailed"
+        : `Account created, but the email failed: ${mail.error}`;
+    } catch (error) {
+      result.status = "failed";
+      result.message = error?.message || "Failed to create the account";
+    }
+  });
+
+  const summary = {
+    total: results.length,
+    created: results.filter((r) => r.status === "created").length,
+    skipped: results.filter((r) => r.status === "skipped").length,
+    failed: results.filter((r) => r.status === "failed").length,
+    mailsSent: results.filter((r) => r.mailSent).length,
+  };
+  summary.mailsFailed = summary.created - summary.mailsSent;
+
+  return res
+    .status(200)
+    .json(
+      new ApiResponse(
+        200,
+        { fileName: req.file.originalname, summary, results },
+        `${summary.created} of ${summary.total} account(s) created`
+      )
+    );
+});
+
+/**
+ * POST /api/v1/admin/user-import/register
+ * Single student onboarding, same rules as a one row CSV.
+ */
+const registerUserByAdmin = asyncHandler(async (req, res) => {
+  const { data, errors } = validateRecord({
+    rollNumber: req.body.rollNumber,
+    fullName: req.body.fullName,
+    email: req.body.email,
+    batch: req.body.batch,
+    branch: req.body.branch,
+    section: req.body.section,
+    mobileNumber: req.body.mobileNumber,
+    username: req.body.username,
+  });
+
+  if (errors.length) {
+    throw new ApiError(400, errors.join("; "));
+  }
+
+  const permissionError = batchPermissionError(req.admin, data.batch);
+  if (permissionError) {
+    throw new ApiError(403, permissionError);
+  }
+
+  const existing = await User.findOne({
+    $or: [
+      { email: data.email },
+      { rollNumber: data.rollNumber },
+      { username: data.username },
+    ],
+  }).select("email rollNumber username");
+
+  if (existing) {
+    const clash =
+      existing.email === data.email
+        ? "email"
+        : existing.rollNumber === data.rollNumber
+          ? "roll number"
+          : "username";
+    throw new ApiError(409, `An account with this ${clash} already exists`);
+  }
+
+  const autoVerify = req.body.autoVerify !== false && req.body.autoVerify !== "false";
+  const sendEmail = req.body.sendEmail !== false && req.body.sendEmail !== "false";
+
+  const { userId, mail } = await createUserAndNotify(data, autoVerify, sendEmail);
+
+  return res.status(201).json(
+    new ApiResponse(
+      201,
+      {
+        userId,
+        rollNumber: data.rollNumber,
+        email: data.email,
+        batch: data.batch,
+        isVerified: autoVerify,
+        mailSent: mail.sent,
+        mailError: mail.sent ? null : mail.error,
+      },
+      mail.sent
+        ? "Account created and credentials emailed"
+        : sendEmail
+          ? `Account created, but the email failed: ${mail.error}`
+          : "Account created"
+    )
+  );
+});
+
+export {
+  downloadUserImportTemplate,
+  importUsersFromCSV,
+  previewUserImport,
+  registerUserByAdmin,
+};

--- a/backend/src/middlewares/csvUpload.middleware.js
+++ b/backend/src/middlewares/csvUpload.middleware.js
@@ -1,0 +1,50 @@
+import multer from "multer";
+import { ApiError } from "../utils/ApiError.js";
+
+const ALLOWED_MIME_TYPES = [
+  "text/csv",
+  "application/csv",
+  "text/plain",
+  "application/vnd.ms-excel",
+  "application/octet-stream",
+];
+
+/**
+ * CSV uploads are parsed in-process, so they are kept in memory instead of
+ * being written to disk like the Cloudinary uploads elsewhere in the app.
+ */
+const uploadCSV = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 2 * 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    const isCsvName = /\.csv$/i.test(file.originalname || "");
+    if (!isCsvName || !ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      return cb(new ApiError(400, "Only .csv files are accepted"));
+    }
+    cb(null, true);
+  },
+});
+
+/**
+ * Multer wrapper that reports upload failures (wrong type, file too large) in
+ * the same JSON envelope the rest of the API uses, since this app has no
+ * global express error handler mounted.
+ * @param {string} fieldName - multipart field carrying the CSV
+ */
+export const singleCSV =
+  (fieldName = "file") =>
+  (req, res, next) => {
+    uploadCSV.single(fieldName)(req, res, (err) => {
+      if (!err) return next();
+      const statusCode = err.statusCode || 400;
+      const message =
+        err.code === "LIMIT_FILE_SIZE"
+          ? "CSV file is too large (max 2 MB)"
+          : err.message || "Failed to read the uploaded file";
+      return res.status(statusCode).json({
+        statusCode,
+        success: false,
+        message,
+      });
+    });
+  };

--- a/backend/src/models/user.model.js
+++ b/backend/src/models/user.model.js
@@ -364,6 +364,46 @@ const userSchema = new Schema(
     refreshToken: {
       type: String,
     },
+    /**
+     * Tracks admin-driven onboarding. Because the mail provider caps how many
+     * messages can go out at once, account creation and the welcome mail are
+     * separate steps: accounts are created as "pending" and mailed later in
+     * batches. Users who signed up themselves stay "not_required".
+     */
+    onboarding: {
+      isAdminOnboarded: {
+        type: Boolean,
+        default: false,
+      },
+      welcomeMailStatus: {
+        type: String,
+        enum: ["not_required", "pending", "sent", "failed"],
+        default: "not_required",
+        index: true,
+      },
+      welcomeMailSentAt: {
+        type: Date,
+        default: null,
+        index: true,
+      },
+      welcomeMailAttempts: {
+        type: Number,
+        default: 0,
+      },
+      welcomeMailError: {
+        type: String,
+        default: "",
+      },
+      onboardedAt: {
+        type: Date,
+        default: null,
+      },
+      onboardedBy: {
+        type: Schema.Types.ObjectId,
+        ref: "Admin",
+        default: null,
+      },
+    },
   },
   { timestamps: true }
 );

--- a/backend/src/routes/admin.routes.js
+++ b/backend/src/routes/admin.routes.js
@@ -32,6 +32,13 @@ import {
   assignCompany,
   getAllCompanies,
 } from "../controllers/company.controller.js";
+import {
+  downloadUserImportTemplate,
+  importUsersFromCSV,
+  previewUserImport,
+  registerUserByAdmin,
+} from "../controllers/userImport.controller.js";
+import { singleCSV } from "../middlewares/csvUpload.middleware.js";
 const router = Router();
 
 /**
@@ -66,6 +73,18 @@ router.route("/assign-company").post(verifyAdmin, assignCompany);
 router.route("/get-minor-projects").get(verifyAdmin, getAllMinorProjects);
 router.route("/get-major-projects").get(verifyAdmin, getAllMajorProjects);
 router.route("/batch-stats").get(verifyAdmin, getBatchStats);
+
+// User onboarding: CSV bulk import + single registration
+router
+  .route("/user-import/template")
+  .get(verifyAdmin, downloadUserImportTemplate);
+router
+  .route("/user-import/preview")
+  .post(verifyAdmin, singleCSV("file"), previewUserImport);
+router
+  .route("/user-import/import")
+  .post(verifyAdmin, singleCSV("file"), importUsersFromCSV);
+router.route("/user-import/register").post(verifyAdmin, registerUserByAdmin);
 
 // Master admin only routes
 router.route("/admins").get(verifyMasterAdmin, getAllAdmins);

--- a/backend/src/routes/admin.routes.js
+++ b/backend/src/routes/admin.routes.js
@@ -34,9 +34,12 @@ import {
 } from "../controllers/company.controller.js";
 import {
   downloadUserImportTemplate,
+  getMailQuotaStatus,
   importUsersFromCSV,
+  listPendingWelcomeMails,
   previewUserImport,
   registerUserByAdmin,
+  sendWelcomeMails,
 } from "../controllers/userImport.controller.js";
 import { singleCSV } from "../middlewares/csvUpload.middleware.js";
 const router = Router();
@@ -85,6 +88,9 @@ router
   .route("/user-import/import")
   .post(verifyAdmin, singleCSV("file"), importUsersFromCSV);
 router.route("/user-import/register").post(verifyAdmin, registerUserByAdmin);
+router.route("/user-import/pending").get(verifyAdmin, listPendingWelcomeMails);
+router.route("/user-import/quota").get(verifyAdmin, getMailQuotaStatus);
+router.route("/user-import/send-mails").post(verifyAdmin, sendWelcomeMails);
 
 // Master admin only routes
 router.route("/admins").get(verifyMasterAdmin, getAllAdmins);

--- a/backend/src/utils/csv.js
+++ b/backend/src/utils/csv.js
@@ -1,0 +1,117 @@
+/**
+ * Minimal dependency-free CSV helpers (RFC 4180 style).
+ *
+ * Handles quoted fields, escaped quotes (""), embedded commas/newlines,
+ * BOM stripping and both CRLF / LF line endings.
+ */
+
+/**
+ * Split raw CSV text into an array of string arrays.
+ * @param {string} text
+ * @returns {string[][]}
+ */
+const splitRecords = (text) => {
+  const records = [];
+  let record = [];
+  let field = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+
+    if (inQuotes) {
+      if (char === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += char;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inQuotes = true;
+    } else if (char === ",") {
+      record.push(field);
+      field = "";
+    } else if (char === "\r") {
+      // swallow, the \n that follows terminates the record
+    } else if (char === "\n") {
+      record.push(field);
+      records.push(record);
+      record = [];
+      field = "";
+    } else {
+      field += char;
+    }
+  }
+
+  if (field !== "" || record.length > 0) {
+    record.push(field);
+    records.push(record);
+  }
+
+  return records;
+};
+
+/**
+ * Parse CSV text into headers + row objects keyed by header.
+ * Fully blank lines are skipped, and each row keeps the physical line number
+ * (1-based, header included) so errors can be reported back to the uploader.
+ *
+ * @param {string} text
+ * @returns {{ headers: string[], rows: Array<{ lineNumber: number, values: Record<string,string> }> }}
+ */
+export const parseCSV = (text = "") => {
+  const clean = text.replace(/^﻿/, "");
+  const records = splitRecords(clean);
+
+  if (records.length === 0) {
+    return { headers: [], rows: [] };
+  }
+
+  const headers = records[0].map((h) => h.trim());
+  const rows = [];
+
+  for (let i = 1; i < records.length; i++) {
+    const record = records[i];
+    const isBlank = record.every((cell) => cell.trim() === "");
+    if (isBlank) continue;
+
+    const values = {};
+    headers.forEach((header, index) => {
+      values[header] = (record[index] ?? "").trim();
+    });
+    rows.push({ lineNumber: i + 1, values });
+  }
+
+  return { headers, rows };
+};
+
+/**
+ * Escape a single CSV cell.
+ * @param {unknown} value
+ * @returns {string}
+ */
+const escapeCell = (value) => {
+  const str = value === null || value === undefined ? "" : String(value);
+  return /[",\r\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+};
+
+/**
+ * Serialise an array of objects into CSV text.
+ * @param {string[]} headers
+ * @param {Array<Record<string, unknown>>} rows
+ * @returns {string}
+ */
+export const toCSV = (headers, rows = []) => {
+  const lines = [headers.map(escapeCell).join(",")];
+  rows.forEach((row) => {
+    lines.push(headers.map((header) => escapeCell(row[header])).join(","));
+  });
+  return lines.join("\r\n");
+};

--- a/backend/src/utils/mailer.js
+++ b/backend/src/utils/mailer.js
@@ -1,0 +1,151 @@
+import nodemailer from "nodemailer";
+
+let cachedTransporter = null;
+
+/**
+ * Pooled transporter reused across a bulk send so we don't open a fresh
+ * SMTP connection per recipient.
+ * @returns {import("nodemailer").Transporter}
+ */
+const getTransporter = () => {
+  if (!cachedTransporter) {
+    cachedTransporter = nodemailer.createTransport({
+      service: "gmail",
+      pool: true,
+      maxConnections: 3,
+      maxMessages: 50,
+      auth: {
+        user: process.env.AUTH_EMAIL,
+        pass: process.env.AUTH_PASSWORD,
+      },
+    });
+  }
+  return cachedTransporter;
+};
+
+/**
+ * Send a single mail. Never throws - returns a result object so bulk callers
+ * can report per-recipient status.
+ * @param {{ to: string, subject: string, html: string }} options
+ * @returns {Promise<{ sent: boolean, error?: string }>}
+ */
+export const sendMail = async ({ to, subject, html }) => {
+  try {
+    await getTransporter().sendMail({
+      from: process.env.AUTH_EMAIL,
+      to,
+      subject,
+      html,
+    });
+    return { sent: true };
+  } catch (error) {
+    console.error("Error sending email to:", to, error.message);
+    return { sent: false, error: error.message };
+  }
+};
+
+/**
+ * Base URL of the student facing app, used for the login link in emails.
+ * @returns {string}
+ */
+export const getClientUrl = () =>
+  (process.env.CLIENT_URL || process.env.CORS_ORIGIN || "http://localhost:5173")
+    .split(",")[0]
+    .trim()
+    .replace(/\/$/, "");
+
+/**
+ * Welcome email sent to a student account created by an admin.
+ * @param {{ fullName: string, username: string, email: string, password: string }} user
+ * @returns {{ subject: string, html: string }}
+ */
+export const buildWelcomeEmail = ({ fullName, username, email, password }) => {
+  const loginUrl = `${getClientUrl()}/log`;
+
+  return {
+    subject: "Welcome to BITAcademia - Your Account Credentials",
+    html: `
+      <html>
+      <head>
+        <style>
+          .email-container {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            max-width: 600px;
+            margin: 0 auto;
+            border: 1px solid #dddddd;
+            border-radius: 5px;
+            overflow: hidden;
+          }
+          .header {
+            background-color: #007bff;
+            color: white;
+            padding: 20px;
+            text-align: center;
+            font-size: 24px;
+          }
+          .content {
+            padding: 30px;
+            background-color: #ffffff;
+          }
+          .content p {
+            font-size: 16px;
+            margin: 0 0 15px;
+          }
+          .creds {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 20px 0;
+          }
+          .creds td {
+            padding: 8px;
+            border: 1px solid #dddddd;
+            font-size: 16px;
+          }
+          .creds td:first-child {
+            font-weight: bold;
+            width: 35%;
+            background-color: #f7f7f7;
+          }
+          .btn {
+            display: inline-block;
+            background-color: #007bff;
+            color: #ffffff !important;
+            padding: 12px 24px;
+            border-radius: 4px;
+            text-decoration: none;
+            font-weight: bold;
+          }
+          .footer {
+            background-color: #f2f2f2;
+            padding: 15px;
+            text-align: center;
+            font-size: 14px;
+            color: #888888;
+          }
+        </style>
+      </head>
+      <body>
+        <div class="email-container">
+          <div class="header">Welcome to BITAcademia!</div>
+          <div class="content">
+            <p>Hello ${fullName || "there"},</p>
+            <p>An account has been created for you on BITAcademia by your department admin. Use the credentials below to log in:</p>
+            <table class="creds">
+              <tr><td>Username</td><td>${username}</td></tr>
+              <tr><td>Email</td><td>${email}</td></tr>
+              <tr><td>Temporary Password</td><td>${password}</td></tr>
+            </table>
+            <p style="text-align:center;"><a class="btn" href="${loginUrl}">Log in to BITAcademia</a></p>
+            <p>For your security, please change this temporary password after your first login.</p>
+            <p>If you believe this account was created by mistake, please contact your department admin.</p>
+            <p>Best regards,</p>
+            <p>TEAM BITACADEMIA</p>
+          </div>
+          <div class="footer">&copy; BITAcademia. All rights reserved.</div>
+        </div>
+      </body>
+      </html>
+    `,
+  };
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,7 @@ import AdminBugTrackerSummary from "./components/AdminBugTrackerSummary";
 import AdminDashboard from "./components/AdminDashboard";
 import ProfessorTable from "./components/AdminProfessorsTable";
 import AdminRoomRequests from "./components/AdminRoomRequests";
+import AdminUserImport from "./components/AdminUserImport";
 import Alumni from "./components/Alumni";
 import Awardform from "./components/award-form";
 import AwardTable from "./components/AwardTable";
@@ -173,6 +174,7 @@ export default function App() {
           <Route index element={<Dashboard />} />
           <Route path="student-table" element={<StudentTable />} />
           <Route path="verify-users" element={<VerifyUsers />} />
+          <Route path="user-onboarding" element={<AdminUserImport />} />
           <Route path="show-all-alumni" element={<ShowAllAlumni />} />
           <Route
             path="admin-academic-form"

--- a/frontend/src/components/AdminUserImport.jsx
+++ b/frontend/src/components/AdminUserImport.jsx
@@ -1,0 +1,603 @@
+import axios from "axios";
+import { useMemo, useRef, useState } from "react";
+import {
+  HiCheckCircle,
+  HiCloudUpload,
+  HiDocumentDownload,
+  HiExclamationCircle,
+  HiMail,
+  HiUserAdd,
+  HiXCircle,
+} from "react-icons/hi";
+import Swal from "sweetalert2";
+
+const REQUEST_TIMEOUT = 5 * 60 * 1000; // bulk mailing can take a while
+
+const EMPTY_FORM = {
+  rollNumber: "",
+  fullName: "",
+  email: "",
+  batch: "",
+  branch: "",
+  section: "",
+  mobileNumber: "",
+  username: "",
+};
+
+const statusStyles = {
+  ready: "bg-green-100 text-green-700",
+  created: "bg-green-100 text-green-700",
+  invalid: "bg-red-100 text-red-700",
+  failed: "bg-red-100 text-red-700",
+  skipped: "bg-yellow-100 text-yellow-700",
+};
+
+const StatusPill = ({ status }) => (
+  <span
+    className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-semibold capitalize ${
+      statusStyles[status] || "bg-gray-100 text-gray-700"
+    }`}
+  >
+    {status}
+  </span>
+);
+
+const SummaryCard = ({ label, value, tone = "gray" }) => {
+  const tones = {
+    gray: "border-gray-200 text-gray-700",
+    green: "border-green-300 text-green-700",
+    red: "border-red-300 text-red-700",
+    yellow: "border-yellow-300 text-yellow-700",
+    blue: "border-blue-300 text-blue-700",
+  };
+  return (
+    <div className={`rounded-lg border bg-white px-4 py-3 shadow-sm ${tones[tone]}`}>
+      <p className="text-2xl font-bold">{value}</p>
+      <p className="text-xs font-medium uppercase tracking-wide text-gray-500">
+        {label}
+      </p>
+    </div>
+  );
+};
+
+const readApiError = (err, fallback) =>
+  err?.response?.data?.message || err?.message || fallback;
+
+const AdminUserImport = () => {
+  const [tab, setTab] = useState("csv");
+
+  // CSV import state
+  const [file, setFile] = useState(null);
+  const [preview, setPreview] = useState(null);
+  const [importResult, setImportResult] = useState(null);
+  const [autoVerify, setAutoVerify] = useState(true);
+  const [sendEmail, setSendEmail] = useState(true);
+  const [previewing, setPreviewing] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const fileInputRef = useRef(null);
+
+  // Single registration state
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+
+  const readyCount = preview?.summary?.ready ?? 0;
+
+  const rowsToShow = useMemo(() => {
+    if (importResult) return importResult.results;
+    return preview?.rows ?? [];
+  }, [preview, importResult]);
+
+  const resetCsvState = () => {
+    setFile(null);
+    setPreview(null);
+    setImportResult(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const handleFileChange = (event) => {
+    const selected = event.target.files?.[0] || null;
+    setFile(selected);
+    setPreview(null);
+    setImportResult(null);
+  };
+
+  const handleDownloadTemplate = async () => {
+    try {
+      const response = await axios.get("/api/v1/admin/user-import/template", {
+        responseType: "blob",
+      });
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", "user-import-template.csv");
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      Swal.fire({
+        icon: "error",
+        title: "Download failed",
+        text: readApiError(err, "Could not download the template."),
+      });
+    }
+  };
+
+  const handlePreview = async () => {
+    if (!file) {
+      Swal.fire({
+        icon: "warning",
+        title: "No file selected",
+        text: "Choose a .csv file first.",
+      });
+      return;
+    }
+    try {
+      setPreviewing(true);
+      setImportResult(null);
+      const formData = new FormData();
+      formData.append("file", file);
+      const response = await axios.post(
+        "/api/v1/admin/user-import/preview",
+        formData,
+        { timeout: REQUEST_TIMEOUT }
+      );
+      setPreview(response.data.data);
+    } catch (err) {
+      setPreview(null);
+      Swal.fire({
+        icon: "error",
+        title: "Could not read the CSV",
+        text: readApiError(err, "Failed to validate the file."),
+      });
+    } finally {
+      setPreviewing(false);
+    }
+  };
+
+  const handleImport = async () => {
+    if (!file || readyCount === 0) return;
+
+    const confirmed = await Swal.fire({
+      icon: "question",
+      title: `Onboard ${readyCount} student(s)?`,
+      html: sendEmail
+        ? "Accounts will be created and login credentials emailed to each student."
+        : "Accounts will be created. <b>No emails will be sent.</b>",
+      showCancelButton: true,
+      confirmButtonText: "Yes, create accounts",
+      confirmButtonColor: "#2563eb",
+    });
+    if (!confirmed.isConfirmed) return;
+
+    try {
+      setImporting(true);
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("autoVerify", String(autoVerify));
+      formData.append("sendEmail", String(sendEmail));
+      const response = await axios.post(
+        "/api/v1/admin/user-import/import",
+        formData,
+        { timeout: REQUEST_TIMEOUT }
+      );
+      const data = response.data.data;
+      setImportResult(data);
+      Swal.fire({
+        icon: data.summary.created > 0 ? "success" : "warning",
+        title: "Import finished",
+        text: `${data.summary.created} created, ${data.summary.skipped} skipped, ${data.summary.failed} failed, ${data.summary.mailsSent} email(s) sent.`,
+      });
+    } catch (err) {
+      Swal.fire({
+        icon: "error",
+        title: "Import failed",
+        text: readApiError(err, "Failed to import the file."),
+      });
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const handleDownloadReport = () => {
+    if (!importResult) return;
+    const headers = [
+      "rowNumber",
+      "rollNumber",
+      "fullName",
+      "email",
+      "batch",
+      "status",
+      "mailSent",
+      "message",
+    ];
+    const escape = (value) => {
+      const str = value === null || value === undefined ? "" : String(value);
+      return /[",\r\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+    };
+    const csv = [
+      headers.join(","),
+      ...importResult.results.map((row) =>
+        headers.map((header) => escape(row[header])).join(",")
+      ),
+    ].join("\r\n");
+
+    const url = window.URL.createObjectURL(
+      new Blob([csv], { type: "text/csv;charset=utf-8;" })
+    );
+    const link = document.createElement("a");
+    link.href = url;
+    link.setAttribute("download", "user-import-report.csv");
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.URL.revokeObjectURL(url);
+  };
+
+  const handleFormChange = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSingleSubmit = async (event) => {
+    event.preventDefault();
+    try {
+      setSaving(true);
+      const response = await axios.post("/api/v1/admin/user-import/register", {
+        ...form,
+        autoVerify,
+        sendEmail,
+      });
+      const data = response.data.data;
+      Swal.fire({
+        icon: data.mailSent || !sendEmail ? "success" : "warning",
+        title: "Account created",
+        text: response.data.message,
+      });
+      setForm(EMPTY_FORM);
+    } catch (err) {
+      Swal.fire({
+        icon: "error",
+        title: "Could not create the account",
+        text: readApiError(err, "Failed to register the student."),
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-4 md:p-8">
+      <div className="mx-auto max-w-6xl">
+        <header className="mb-6">
+          <h1 className="flex items-center gap-2 text-3xl font-bold text-blue-700">
+            <HiUserAdd /> User Onboarding
+          </h1>
+          <p className="mt-1 text-gray-600">
+            Bulk-register students from a CSV file or add them one at a time. Each
+            new account gets a generated password emailed to them.
+          </p>
+        </header>
+
+        {/* Tabs */}
+        <div className="mb-6 flex gap-2 border-b border-gray-200">
+          {[
+            { key: "csv", label: "CSV Import", icon: <HiCloudUpload /> },
+            { key: "single", label: "Single User", icon: <HiUserAdd /> },
+          ].map((item) => (
+            <button
+              key={item.key}
+              type="button"
+              onClick={() => setTab(item.key)}
+              className={`-mb-px flex items-center gap-2 border-b-2 px-4 py-2 font-semibold transition ${
+                tab === item.key
+                  ? "border-blue-600 text-blue-700"
+                  : "border-transparent text-gray-500 hover:text-gray-700"
+              }`}
+            >
+              {item.icon}
+              {item.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Shared options */}
+        <div className="mb-6 flex flex-wrap gap-6 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+          <label className="flex items-center gap-2 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              checked={sendEmail}
+              onChange={(e) => setSendEmail(e.target.checked)}
+              className="h-4 w-4"
+            />
+            <HiMail className="text-blue-600" />
+            Email login credentials to each new user
+          </label>
+          <label className="flex items-center gap-2 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              checked={autoVerify}
+              onChange={(e) => setAutoVerify(e.target.checked)}
+              className="h-4 w-4"
+            />
+            <HiCheckCircle className="text-green-600" />
+            Mark accounts as verified (they can log in immediately)
+          </label>
+        </div>
+
+        {tab === "csv" && (
+          <section className="space-y-6">
+            <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+              <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+                <h2 className="text-lg font-semibold text-gray-800">
+                  1. Upload the CSV
+                </h2>
+                <button
+                  type="button"
+                  onClick={handleDownloadTemplate}
+                  className="flex items-center gap-2 rounded-lg border border-blue-600 px-4 py-2 text-sm font-semibold text-blue-700 transition hover:bg-blue-50"
+                >
+                  <HiDocumentDownload /> Download template
+                </button>
+              </div>
+
+              <p className="mb-4 text-sm text-gray-600">
+                Required columns:{" "}
+                <code className="rounded bg-gray-100 px-1">rollNumber</code>,{" "}
+                <code className="rounded bg-gray-100 px-1">fullName</code>,{" "}
+                <code className="rounded bg-gray-100 px-1">email</code>,{" "}
+                <code className="rounded bg-gray-100 px-1">batch</code>. Optional:{" "}
+                <code className="rounded bg-gray-100 px-1">branch</code>,{" "}
+                <code className="rounded bg-gray-100 px-1">section</code>,{" "}
+                <code className="rounded bg-gray-100 px-1">mobileNumber</code>,{" "}
+                <code className="rounded bg-gray-100 px-1">username</code> (defaults
+                to the roll number). Up to 500 rows per file.
+              </p>
+
+              <div className="flex flex-wrap items-center gap-3">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".csv,text/csv"
+                  onChange={handleFileChange}
+                  className="block w-full max-w-sm rounded-lg border border-gray-300 p-2 text-sm file:mr-3 file:rounded file:border-0 file:bg-blue-600 file:px-3 file:py-1.5 file:text-white"
+                />
+                <button
+                  type="button"
+                  onClick={handlePreview}
+                  disabled={!file || previewing}
+                  className="rounded-lg bg-blue-600 px-5 py-2 font-semibold text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-300"
+                >
+                  {previewing ? "Validating..." : "Validate file"}
+                </button>
+                {(file || preview) && (
+                  <button
+                    type="button"
+                    onClick={resetCsvState}
+                    className="rounded-lg border border-gray-300 px-4 py-2 text-sm text-gray-600 transition hover:bg-gray-100"
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {preview && !importResult && (
+              <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+                <h2 className="mb-4 text-lg font-semibold text-gray-800">
+                  2. Review &amp; import
+                </h2>
+                <div className="mb-4 grid grid-cols-2 gap-3 md:grid-cols-3">
+                  <SummaryCard label="Rows found" value={preview.summary.total} />
+                  <SummaryCard
+                    label="Ready"
+                    value={preview.summary.ready}
+                    tone="green"
+                  />
+                  <SummaryCard
+                    label="Needs fixing"
+                    value={preview.summary.invalid}
+                    tone="red"
+                  />
+                </div>
+                {preview.summary.invalid > 0 && (
+                  <p className="mb-4 flex items-start gap-2 rounded border border-yellow-300 bg-yellow-50 p-3 text-sm text-yellow-800">
+                    <HiExclamationCircle className="mt-0.5 shrink-0" />
+                    Rows with errors will be skipped. Fix them in the CSV and upload
+                    again to onboard those students.
+                  </p>
+                )}
+                <button
+                  type="button"
+                  onClick={handleImport}
+                  disabled={readyCount === 0 || importing}
+                  className="rounded-lg bg-green-600 px-5 py-2 font-semibold text-white transition hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-gray-300"
+                >
+                  {importing
+                    ? "Creating accounts..."
+                    : `Create ${readyCount} account(s)${sendEmail ? " & send emails" : ""}`}
+                </button>
+              </div>
+            )}
+
+            {importResult && (
+              <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+                <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+                  <h2 className="text-lg font-semibold text-gray-800">
+                    Import results
+                  </h2>
+                  <button
+                    type="button"
+                    onClick={handleDownloadReport}
+                    className="flex items-center gap-2 rounded-lg border border-blue-600 px-4 py-2 text-sm font-semibold text-blue-700 transition hover:bg-blue-50"
+                  >
+                    <HiDocumentDownload /> Download report
+                  </button>
+                </div>
+                <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
+                  <SummaryCard label="Rows" value={importResult.summary.total} />
+                  <SummaryCard
+                    label="Created"
+                    value={importResult.summary.created}
+                    tone="green"
+                  />
+                  <SummaryCard
+                    label="Skipped"
+                    value={importResult.summary.skipped}
+                    tone="yellow"
+                  />
+                  <SummaryCard
+                    label="Failed"
+                    value={importResult.summary.failed}
+                    tone="red"
+                  />
+                  <SummaryCard
+                    label="Emails sent"
+                    value={importResult.summary.mailsSent}
+                    tone="blue"
+                  />
+                </div>
+              </div>
+            )}
+
+            {rowsToShow.length > 0 && (
+              <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white shadow-sm">
+                <table className="min-w-full text-sm">
+                  <thead className="bg-gray-100 text-left text-gray-700">
+                    <tr>
+                      <th className="px-4 py-3">#</th>
+                      <th className="px-4 py-3">Roll Number</th>
+                      <th className="px-4 py-3">Name</th>
+                      <th className="px-4 py-3">Email</th>
+                      <th className="px-4 py-3">Batch</th>
+                      <th className="px-4 py-3">Status</th>
+                      {importResult && <th className="px-4 py-3">Mail</th>}
+                      <th className="px-4 py-3">Details</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {rowsToShow.map((row) => {
+                      const info = importResult ? row : row.data;
+                      const details = importResult
+                        ? row.message
+                        : row.errors.join("; ");
+                      return (
+                        <tr
+                          key={row.rowNumber}
+                          className="border-t border-gray-100 align-top"
+                        >
+                          <td className="px-4 py-3 text-gray-500">
+                            {row.rowNumber}
+                          </td>
+                          <td className="px-4 py-3">{info.rollNumber || "—"}</td>
+                          <td className="px-4 py-3 capitalize">
+                            {info.fullName || "—"}
+                          </td>
+                          <td className="px-4 py-3">{info.email || "—"}</td>
+                          <td className="px-4 py-3">
+                            {info.batch !== null && info.batch !== undefined
+                              ? `K${info.batch}`
+                              : "—"}
+                          </td>
+                          <td className="px-4 py-3">
+                            <StatusPill status={row.status} />
+                          </td>
+                          {importResult && (
+                            <td className="px-4 py-3">
+                              {row.status === "created" ? (
+                                row.mailSent ? (
+                                  <HiCheckCircle
+                                    className="text-lg text-green-600"
+                                    title="Email sent"
+                                  />
+                                ) : (
+                                  <HiXCircle
+                                    className="text-lg text-red-600"
+                                    title="Email not sent"
+                                  />
+                                )
+                              ) : (
+                                "—"
+                              )}
+                            </td>
+                          )}
+                          <td className="px-4 py-3 text-gray-600">
+                            {details || "—"}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        )}
+
+        {tab === "single" && (
+          <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+            <h2 className="mb-4 text-lg font-semibold text-gray-800">
+              Register a single student
+            </h2>
+            <form onSubmit={handleSingleSubmit} className="grid gap-4 md:grid-cols-2">
+              {[
+                { name: "rollNumber", label: "Roll Number", required: true },
+                { name: "fullName", label: "Full Name", required: true },
+                {
+                  name: "email",
+                  label: "Email",
+                  required: true,
+                  type: "email",
+                },
+                {
+                  name: "batch",
+                  label: "Batch (e.g. 22, K22 or 2022)",
+                  required: true,
+                },
+                { name: "branch", label: "Branch" },
+                { name: "section", label: "Section" },
+                { name: "mobileNumber", label: "Mobile Number (10 digits)" },
+                {
+                  name: "username",
+                  label: "Username (defaults to roll number)",
+                },
+              ].map((field) => (
+                <div key={field.name}>
+                  <label
+                    htmlFor={field.name}
+                    className="mb-1 block text-sm font-semibold text-gray-700"
+                  >
+                    {field.label}
+                    {field.required && <span className="text-red-500"> *</span>}
+                  </label>
+                  <input
+                    id={field.name}
+                    name={field.name}
+                    type={field.type || "text"}
+                    value={form[field.name]}
+                    onChange={handleFormChange}
+                    required={field.required}
+                    className="w-full rounded-lg border border-gray-300 p-3 transition focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+              ))}
+
+              <div className="md:col-span-2">
+                <button
+                  type="submit"
+                  disabled={saving}
+                  className="flex items-center gap-2 rounded-lg bg-blue-600 px-6 py-3 font-semibold text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-300"
+                >
+                  <HiUserAdd />
+                  {saving ? "Creating..." : "Create account"}
+                </button>
+              </div>
+            </form>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AdminUserImport;

--- a/frontend/src/components/AdminUserImport.jsx
+++ b/frontend/src/components/AdminUserImport.jsx
@@ -1,11 +1,13 @@
 import axios from "axios";
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   HiCheckCircle,
   HiCloudUpload,
   HiDocumentDownload,
   HiExclamationCircle,
   HiMail,
+  HiPaperAirplane,
+  HiRefresh,
   HiUserAdd,
   HiXCircle,
 } from "react-icons/hi";
@@ -27,9 +29,12 @@ const EMPTY_FORM = {
 const statusStyles = {
   ready: "bg-green-100 text-green-700",
   created: "bg-green-100 text-green-700",
+  done: "bg-green-100 text-green-700",
+  sent: "bg-green-100 text-green-700",
   invalid: "bg-red-100 text-red-700",
   failed: "bg-red-100 text-red-700",
   skipped: "bg-yellow-100 text-yellow-700",
+  pending: "bg-yellow-100 text-yellow-700",
 };
 
 const StatusPill = ({ status }) => (
@@ -63,6 +68,59 @@ const SummaryCard = ({ label, value, tone = "gray" }) => {
 const readApiError = (err, fallback) =>
   err?.response?.data?.message || err?.message || fallback;
 
+/**
+ * Shows how much of the provider's send allowance is left in the current
+ * window, so the admin can size a batch before starting it.
+ */
+const QuotaBanner = ({ quota, onRefresh, refreshing }) => {
+  if (!quota) return null;
+  const pct = quota.limit ? Math.min(100, (quota.used / quota.limit) * 100) : 0;
+  const exhausted = quota.remaining <= 0;
+
+  return (
+    <div
+      className={`rounded-lg border p-4 shadow-sm ${
+        exhausted ? "border-red-300 bg-red-50" : "border-blue-200 bg-blue-50"
+      }`}
+    >
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <p className="font-semibold text-gray-800">
+          Email allowance:{" "}
+          <span className={exhausted ? "text-red-700" : "text-blue-700"}>
+            {quota.remaining} of {quota.limit} left
+          </span>{" "}
+          <span className="text-sm font-normal text-gray-600">
+            (last {quota.windowHours}h)
+          </span>
+        </p>
+        {onRefresh && (
+          <button
+            type="button"
+            onClick={onRefresh}
+            disabled={refreshing}
+            className="flex items-center gap-1 rounded border border-gray-300 bg-white px-3 py-1 text-sm text-gray-700 transition hover:bg-gray-100 disabled:opacity-50"
+          >
+            <HiRefresh className={refreshing ? "animate-spin" : ""} /> Refresh
+          </button>
+        )}
+      </div>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-white">
+        <div
+          className={`h-full ${exhausted ? "bg-red-500" : "bg-blue-500"}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      {exhausted && quota.resetsAt && (
+        <p className="mt-2 text-sm text-red-700">
+          Quota is used up. Capacity frees up from{" "}
+          {new Date(quota.resetsAt).toLocaleString()}. Accounts stay queued until
+          then — nothing is lost.
+        </p>
+      )}
+    </div>
+  );
+};
+
 const AdminUserImport = () => {
   const [tab, setTab] = useState("csv");
 
@@ -76,11 +134,141 @@ const AdminUserImport = () => {
   const [importing, setImporting] = useState(false);
   const fileInputRef = useRef(null);
 
+  const [mailLimit, setMailLimit] = useState("");
+
   // Single registration state
   const [form, setForm] = useState(EMPTY_FORM);
   const [saving, setSaving] = useState(false);
 
+  // Welcome-mail queue state
+  const [queue, setQueue] = useState(null);
+  const [queueStatus, setQueueStatus] = useState("unsent");
+  const [queueSearch, setQueueSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [queuePage, setQueuePage] = useState(1);
+  const [selectedIds, setSelectedIds] = useState([]);
+  const [sendCount, setSendCount] = useState("");
+  const [loadingQueue, setLoadingQueue] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [sendReport, setSendReport] = useState(null);
+
+  const quota = queue?.quota ?? null;
   const readyCount = preview?.summary?.ready ?? 0;
+
+  const fetchQueue = useCallback(async () => {
+    try {
+      setLoadingQueue(true);
+      const response = await axios.get("/api/v1/admin/user-import/pending", {
+        params: {
+          status: queueStatus,
+          search: debouncedSearch || undefined,
+          page: queuePage,
+          limit: 50,
+        },
+      });
+      setQueue(response.data.data);
+    } catch (err) {
+      Swal.fire({
+        icon: "error",
+        title: "Could not load the queue",
+        text: readApiError(err, "Failed to fetch pending welcome emails."),
+      });
+    } finally {
+      setLoadingQueue(false);
+    }
+  }, [queueStatus, debouncedSearch, queuePage]);
+
+  // Keep typing in the search box from firing a request per keystroke.
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(queueSearch), 350);
+    return () => clearTimeout(timer);
+  }, [queueSearch]);
+
+  useEffect(() => {
+    if (tab === "queue") fetchQueue();
+  }, [tab, fetchQueue]);
+
+  const queueUsers = queue?.users ?? [];
+  const selectableIds = useMemo(
+    () =>
+      queueUsers
+        .filter((u) => u.onboarding?.welcomeMailStatus !== "sent")
+        .map((u) => u._id),
+    [queueUsers]
+  );
+  const allSelected =
+    selectableIds.length > 0 &&
+    selectableIds.every((id) => selectedIds.includes(id));
+
+  const toggleSelectAll = () => {
+    setSelectedIds(allSelected ? [] : selectableIds);
+  };
+
+  const toggleOne = (id) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  };
+
+  const dispatchMails = async (payload, confirmText) => {
+    const confirmed = await Swal.fire({
+      icon: "question",
+      title: "Send welcome emails?",
+      text: confirmText,
+      showCancelButton: true,
+      confirmButtonText: "Send",
+      confirmButtonColor: "#2563eb",
+    });
+    if (!confirmed.isConfirmed) return;
+
+    try {
+      setSending(true);
+      const response = await axios.post(
+        "/api/v1/admin/user-import/send-mails",
+        payload,
+        { timeout: REQUEST_TIMEOUT }
+      );
+      const data = response.data.data;
+      setSendReport(data);
+      setSelectedIds([]);
+      await fetchQueue();
+      Swal.fire({
+        icon: data.summary.sent > 0 ? "success" : "warning",
+        title: "Done",
+        text: response.data.message,
+      });
+    } catch (err) {
+      Swal.fire({
+        icon: "error",
+        title: "Sending failed",
+        text: readApiError(err, "Failed to send welcome emails."),
+      });
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleSendSelected = () =>
+    dispatchMails(
+      { userIds: selectedIds },
+      `${selectedIds.length} selected student(s) will receive their login credentials.`
+    );
+
+  const handleSendNext = () => {
+    const n = Number(sendCount);
+    if (!n || n < 1) {
+      Swal.fire({
+        icon: "warning",
+        title: "Enter a number",
+        text: "How many students should be mailed in this batch?",
+      });
+      return;
+    }
+    return dispatchMails(
+      { count: n },
+      `The ${n} longest-waiting student(s) in the queue will be mailed.`
+    );
+  };
 
   const rowsToShow = useMemo(() => {
     if (importResult) return importResult.results;
@@ -176,6 +364,7 @@ const AdminUserImport = () => {
       formData.append("file", file);
       formData.append("autoVerify", String(autoVerify));
       formData.append("sendEmail", String(sendEmail));
+      if (mailLimit !== "") formData.append("mailLimit", String(mailLimit));
       const response = await axios.post(
         "/api/v1/admin/user-import/import",
         formData,
@@ -186,7 +375,11 @@ const AdminUserImport = () => {
       Swal.fire({
         icon: data.summary.created > 0 ? "success" : "warning",
         title: "Import finished",
-        text: `${data.summary.created} created, ${data.summary.skipped} skipped, ${data.summary.failed} failed, ${data.summary.mailsSent} email(s) sent.`,
+        html: `${data.summary.created} created, ${data.summary.skipped} skipped, ${data.summary.failed} failed.<br/>${data.summary.mailsSent} email(s) sent${
+          data.summary.stillQueued > 0
+            ? `, <b>${data.summary.stillQueued} still queued</b> — send them from the Welcome Emails tab.`
+            : "."
+        }`,
       });
     } catch (err) {
       Swal.fire({
@@ -284,6 +477,11 @@ const AdminUserImport = () => {
           {[
             { key: "csv", label: "CSV Import", icon: <HiCloudUpload /> },
             { key: "single", label: "Single User", icon: <HiUserAdd /> },
+            {
+              key: "queue",
+              label: "Welcome Emails",
+              icon: <HiPaperAirplane />,
+            },
           ].map((item) => (
             <button
               key={item.key}
@@ -302,28 +500,51 @@ const AdminUserImport = () => {
         </div>
 
         {/* Shared options */}
-        <div className="mb-6 flex flex-wrap gap-6 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
-          <label className="flex items-center gap-2 text-sm text-gray-700">
-            <input
-              type="checkbox"
-              checked={sendEmail}
-              onChange={(e) => setSendEmail(e.target.checked)}
-              className="h-4 w-4"
-            />
-            <HiMail className="text-blue-600" />
-            Email login credentials to each new user
-          </label>
-          <label className="flex items-center gap-2 text-sm text-gray-700">
-            <input
-              type="checkbox"
-              checked={autoVerify}
-              onChange={(e) => setAutoVerify(e.target.checked)}
-              className="h-4 w-4"
-            />
-            <HiCheckCircle className="text-green-600" />
-            Mark accounts as verified (they can log in immediately)
-          </label>
-        </div>
+        {tab !== "queue" && (
+          <div className="mb-6 space-y-3 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+            <div className="flex flex-wrap gap-6">
+              <label className="flex items-center gap-2 text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  checked={sendEmail}
+                  onChange={(e) => setSendEmail(e.target.checked)}
+                  className="h-4 w-4"
+                />
+                <HiMail className="text-blue-600" />
+                Email credentials right away
+              </label>
+              <label className="flex items-center gap-2 text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  checked={autoVerify}
+                  onChange={(e) => setAutoVerify(e.target.checked)}
+                  className="h-4 w-4"
+                />
+                <HiCheckCircle className="text-green-600" />
+                Mark accounts as verified (they can log in immediately)
+              </label>
+              {tab === "csv" && sendEmail && (
+                <label className="flex items-center gap-2 text-sm text-gray-700">
+                  Mail only the first
+                  <input
+                    type="number"
+                    min="0"
+                    value={mailLimit}
+                    onChange={(e) => setMailLimit(e.target.value)}
+                    placeholder="all"
+                    className="w-20 rounded border border-gray-300 px-2 py-1"
+                  />
+                  student(s)
+                </label>
+              )}
+            </div>
+            <p className="text-xs text-gray-500">
+              Accounts are always created. Anyone not mailed now is queued and
+              stays in the <b>Welcome Emails</b> tab until you send them — the
+              provider&apos;s send limit is never exceeded.
+            </p>
+          </div>
+        )}
 
         {tab === "csv" && (
           <section className="space-y-6">
@@ -434,7 +655,7 @@ const AdminUserImport = () => {
                     <HiDocumentDownload /> Download report
                   </button>
                 </div>
-                <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
+                <div className="grid grid-cols-2 gap-3 md:grid-cols-6">
                   <SummaryCard label="Rows" value={importResult.summary.total} />
                   <SummaryCard
                     label="Created"
@@ -456,7 +677,32 @@ const AdminUserImport = () => {
                     value={importResult.summary.mailsSent}
                     tone="blue"
                   />
+                  <SummaryCard
+                    label="Still queued"
+                    value={importResult.summary.stillQueued}
+                    tone="yellow"
+                  />
                 </div>
+                {importResult.summary.stillQueued > 0 && (
+                  <p className="mt-4 flex items-start gap-2 rounded border border-blue-300 bg-blue-50 p-3 text-sm text-blue-800">
+                    <HiExclamationCircle className="mt-0.5 shrink-0" />
+                    {importResult.summary.stillQueued} account(s) were created but
+                    not mailed, because of the send limit. Open the{" "}
+                    <button
+                      type="button"
+                      onClick={() => setTab("queue")}
+                      className="font-semibold underline"
+                    >
+                      Welcome Emails
+                    </button>{" "}
+                    tab to send them in batches.
+                  </p>
+                )}
+                {importResult.quota && (
+                  <div className="mt-4">
+                    <QuotaBanner quota={importResult.quota} />
+                  </div>
+                )}
               </div>
             )}
 
@@ -593,6 +839,246 @@ const AdminUserImport = () => {
                 </button>
               </div>
             </form>
+          </section>
+        )}
+
+        {tab === "queue" && (
+          <section className="space-y-6">
+            <QuotaBanner
+              quota={quota}
+              onRefresh={fetchQueue}
+              refreshing={loadingQueue}
+            />
+
+            {queue && (
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                <SummaryCard
+                  label="Awaiting email"
+                  value={queue.counts.pending}
+                  tone="yellow"
+                />
+                <SummaryCard
+                  label="Previously failed"
+                  value={queue.counts.failed}
+                  tone="red"
+                />
+                <SummaryCard
+                  label="Done"
+                  value={queue.counts.sent}
+                  tone="green"
+                />
+                <SummaryCard
+                  label="Selected"
+                  value={selectedIds.length}
+                  tone="blue"
+                />
+              </div>
+            )}
+
+            {/* Controls */}
+            <div className="flex flex-wrap items-end gap-4 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+              <div>
+                <label
+                  htmlFor="queueStatus"
+                  className="mb-1 block text-xs font-semibold uppercase text-gray-500"
+                >
+                  Show
+                </label>
+                <select
+                  id="queueStatus"
+                  value={queueStatus}
+                  onChange={(e) => {
+                    setQueueStatus(e.target.value);
+                    setQueuePage(1);
+                    setSelectedIds([]);
+                  }}
+                  className="rounded-lg border border-gray-300 p-2 text-sm"
+                >
+                  <option value="unsent">Not yet emailed</option>
+                  <option value="pending">Pending only</option>
+                  <option value="failed">Failed only</option>
+                  <option value="sent">Done</option>
+                  <option value="all">All onboarded</option>
+                </select>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="queueSearch"
+                  className="mb-1 block text-xs font-semibold uppercase text-gray-500"
+                >
+                  Search
+                </label>
+                <input
+                  id="queueSearch"
+                  value={queueSearch}
+                  onChange={(e) => {
+                    setQueueSearch(e.target.value);
+                    setQueuePage(1);
+                  }}
+                  placeholder="Name, roll number or email"
+                  className="w-64 rounded-lg border border-gray-300 p-2 text-sm"
+                />
+              </div>
+
+              <button
+                type="button"
+                onClick={handleSendSelected}
+                disabled={selectedIds.length === 0 || sending}
+                className="rounded-lg bg-blue-600 px-5 py-2 font-semibold text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-300"
+              >
+                {sending ? "Sending..." : `Send to selected (${selectedIds.length})`}
+              </button>
+
+              <div className="flex items-end gap-2">
+                <div>
+                  <label
+                    htmlFor="sendCount"
+                    className="mb-1 block text-xs font-semibold uppercase text-gray-500"
+                  >
+                    Or send next
+                  </label>
+                  <input
+                    id="sendCount"
+                    type="number"
+                    min="1"
+                    max={quota?.remaining || undefined}
+                    value={sendCount}
+                    onChange={(e) => setSendCount(e.target.value)}
+                    placeholder={quota ? String(quota.remaining) : "50"}
+                    className="w-24 rounded-lg border border-gray-300 p-2 text-sm"
+                  />
+                </div>
+                <button
+                  type="button"
+                  onClick={handleSendNext}
+                  disabled={sending || !quota?.remaining}
+                  className="rounded-lg bg-green-600 px-5 py-2 font-semibold text-white transition hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-gray-300"
+                >
+                  Send batch
+                </button>
+              </div>
+            </div>
+
+            {sendReport && (
+              <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+                <p className="font-semibold text-gray-800">
+                  Last batch: {sendReport.summary.sent} sent,{" "}
+                  {sendReport.summary.failed} failed
+                  {sendReport.summary.droppedForQuota > 0 &&
+                    `, ${sendReport.summary.droppedForQuota} left queued (quota reached)`}
+                </p>
+              </div>
+            )}
+
+            {/* Queue table */}
+            <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white shadow-sm">
+              <table className="min-w-full text-sm">
+                <thead className="bg-gray-100 text-left text-gray-700">
+                  <tr>
+                    <th className="px-4 py-3">
+                      <input
+                        type="checkbox"
+                        checked={allSelected}
+                        onChange={toggleSelectAll}
+                        disabled={selectableIds.length === 0}
+                        className="h-4 w-4"
+                      />
+                    </th>
+                    <th className="px-4 py-3">Roll Number</th>
+                    <th className="px-4 py-3">Name</th>
+                    <th className="px-4 py-3">Email</th>
+                    <th className="px-4 py-3">Batch</th>
+                    <th className="px-4 py-3">Mail status</th>
+                    <th className="px-4 py-3">Sent at</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {loadingQueue && (
+                    <tr>
+                      <td colSpan={7} className="px-4 py-8 text-center text-gray-500">
+                        Loading...
+                      </td>
+                    </tr>
+                  )}
+                  {!loadingQueue && queueUsers.length === 0 && (
+                    <tr>
+                      <td colSpan={7} className="px-4 py-8 text-center text-gray-500">
+                        Nothing here. Every onboarded student in view has been
+                        emailed.
+                      </td>
+                    </tr>
+                  )}
+                  {!loadingQueue &&
+                    queueUsers.map((user) => {
+                      const mailStatus =
+                        user.onboarding?.welcomeMailStatus || "pending";
+                      const isSent = mailStatus === "sent";
+                      return (
+                        <tr key={user._id} className="border-t border-gray-100">
+                          <td className="px-4 py-3">
+                            <input
+                              type="checkbox"
+                              checked={selectedIds.includes(user._id)}
+                              onChange={() => toggleOne(user._id)}
+                              disabled={isSent}
+                              className="h-4 w-4"
+                            />
+                          </td>
+                          <td className="px-4 py-3">{user.rollNumber}</td>
+                          <td className="px-4 py-3 capitalize">{user.fullName}</td>
+                          <td className="px-4 py-3">{user.email}</td>
+                          <td className="px-4 py-3">K{user.batch}</td>
+                          <td className="px-4 py-3">
+                            <StatusPill
+                              status={isSent ? "done" : mailStatus}
+                            />
+                            {mailStatus === "failed" &&
+                              user.onboarding?.welcomeMailError && (
+                                <p className="mt-1 text-xs text-red-600">
+                                  {user.onboarding.welcomeMailError}
+                                </p>
+                              )}
+                          </td>
+                          <td className="px-4 py-3 text-gray-600">
+                            {user.onboarding?.welcomeMailSentAt
+                              ? new Date(
+                                  user.onboarding.welcomeMailSentAt
+                                ).toLocaleString()
+                              : "—"}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                </tbody>
+              </table>
+            </div>
+
+            {queue?.pagination && queue.pagination.pages > 1 && (
+              <div className="flex items-center justify-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => setQueuePage((p) => Math.max(1, p - 1))}
+                  disabled={queuePage <= 1}
+                  className="rounded border border-gray-300 px-3 py-1 text-sm disabled:opacity-40"
+                >
+                  Previous
+                </button>
+                <span className="text-sm text-gray-600">
+                  Page {queue.pagination.page} of {queue.pagination.pages}
+                </span>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setQueuePage((p) => Math.min(queue.pagination.pages, p + 1))
+                  }
+                  disabled={queuePage >= queue.pagination.pages}
+                  className="rounded border border-gray-300 px-3 py-1 text-sm disabled:opacity-40"
+                >
+                  Next
+                </button>
+              </div>
+            )}
           </section>
         )}
       </div>

--- a/frontend/src/components/SideBarAdmin.jsx
+++ b/frontend/src/components/SideBarAdmin.jsx
@@ -13,7 +13,8 @@ import {
     HiOutlineBriefcase,
     HiOutlineLogout,
     HiPresentationChartLine,
-    HiUser
+    HiUser,
+    HiUserAdd
 } from "react-icons/hi";
 import { IoIosArrowBack } from "react-icons/io";
 import { Link, useNavigate } from "react-router-dom";
@@ -47,10 +48,15 @@ export default function Sidebar() {
       icon: <HiUser />, 
       to: "/admin-db/student-table" 
     },
-    { 
-      text: "Verify Users", 
-      icon: <HiUser />, 
-      to: "/admin-db/verify-users" 
+    {
+      text: "Verify Users",
+      icon: <HiUser />,
+      to: "/admin-db/verify-users"
+    },
+    {
+      text: "User Onboarding",
+      icon: <HiUserAdd />,
+      to: "/admin-db/user-onboarding",
     },
     {
       text: "Alumni Profiles",


### PR DESCRIPTION
## What

Adds an admin module that registers students in bulk from a CSV file — or one at a time from a form — and emails each new account its generated login credentials.

Because the mail provider caps how many messages can go out per window, **account creation and mail delivery are decoupled**: accounts are always created and queued, and mailing is a separate, resumable step the admin drives in batches.

Reachable at **Admin → User Onboarding** (`/admin-db/user-onboarding`).

## How onboarding works

1. **Prepare** — download the CSV template. Required: `rollNumber`, `fullName`, `email`, `batch`. Optional: `branch`, `section`, `mobileNumber`, `username`. Header aliases are accepted (`roll number`, `name`, `phone`, `dept`), so a registrar's export usually imports unedited.
2. **Validate (dry run)** — `/preview` writes nothing. It checks formats, normalises batch (`22` / `K22` / `2022` → `22`), derives usernames from roll numbers, and flags duplicates inside the file, duplicates against existing accounts, and rows outside a batch admin's assigned batches.
3. **Create accounts** — valid rows become `User` documents marked `welcomeMailStatus: "pending"`. Invalid rows are skipped and reported per row; one bad row never fails the batch.
4. **Send credentials** — quota-bounded and resumable. See below.
5. **Student logs in** — receives username, temporary password and a login link, and is prompted to change the password.

## Mail quota handling

A 900-student import creates 900 accounts and mails the first 100. The other 800 stay queued — nothing is lost, nothing needs re-uploading.

The **Welcome Emails** tab provides:

- **Allowance banner** — "73 of 100 left (last 24h)", with the time capacity frees up once exhausted.
- **Two ways to select** — tick individuals, or "send next N" to mail the longest-waiting N (oldest first).
- **Marked done on send** — each success flips the account to `sent` with a timestamp, so it leaves the queue and is never mailed twice. Failures record the provider error, stay selectable and can be retried.
- Status filters (pending / failed / done / all), debounced search, pagination.

The cap is enforced server-side as well: selecting 300 with 40 left sends 40 and reports `droppedForQuota: 260`. Configurable via `ONBOARDING_MAIL_LIMIT` (default 100) and `ONBOARDING_MAIL_WINDOW_HOURS` (default 24).

## Backend

| File | Purpose |
| --- | --- |
| `utils/csv.js` | Dependency-free RFC 4180 parser/serializer — quoted fields, escaped `""`, embedded commas/newlines, BOM, CRLF, blank lines, source line tracking |
| `utils/mailer.js` | Pooled nodemailer transport + welcome-credentials template |
| `middlewares/csvUpload.middleware.js` | Memory-storage multer, `.csv` only, 2 MB cap |
| `controllers/userImport.controller.js` | Template, preview, import, single registration, queue listing, batched sending |
| `models/user.model.js` | `onboarding` sub-document: mail status, sent timestamp, attempts, last error, who onboarded |

Routes, all behind `verifyAdmin`:

- `GET  /api/v1/admin/user-import/template` — downloadable CSV template
- `POST /api/v1/admin/user-import/preview` — validates without writing
- `POST /api/v1/admin/user-import/import` — creates accounts, mails up to the quota
- `POST /api/v1/admin/user-import/register` — single student
- `GET  /api/v1/admin/user-import/pending` — the queue, with counts and quota
- `GET  /api/v1/admin/user-import/quota` — current allowance
- `POST /api/v1/admin/user-import/send-mails` — mail explicit `userIds`, or the next `count`

Batch admins only ever see and act on their `assignedBatches`; master admins see everything.

## Three things reviewers should look at

1. **Passwords are generated at send time, not creation time.** Otherwise a queued account would need its plaintext password stored for days. `sendWelcomeMailToUser` rotates the password and saves it hashed *before* the mail goes out, so a crash mid-send can leave an undelivered password but never a delivered one that doesn't work. Retrying rotates again, which is safe because the account has not been used yet. Only `pending`/`failed` accounts are eligible, so a student who already logged in and changed their password cannot be clobbered.
2. **The quota counter tracks onboarding mails only.** OTP and verification mails sent elsewhere consume the same provider allowance but are invisible to it, so `ONBOARDING_MAIL_LIMIT` should be set below the true cap.
3. **`idCard` is a required field these users can't satisfy.** It is set to the marker `"admin-onboarded"`, and accounts are auto-verified by default so they don't pile up in Verify Users. Both are toggleable in the UI.

Separately: `app.js` imports `errorHandler` but never mounts it, so an unwrapped multer error would return an HTML 500. The upload middleware wraps multer and returns the usual JSON envelope. Worth fixing globally in another PR.

## Frontend

`components/AdminUserImport.jsx` — three tabs:

- **CSV Import** — template → upload → validate → per-row review → import → results with a downloadable report CSV, plus an optional "mail only the first N"
- **Single User** — form for one-off additions
- **Welcome Emails** — the queue described above

Plus the sidebar entry and route in `App.jsx`.

## Testing

- `node --check` passes on all new and changed backend files.
- The CSV parser and validation helpers (batch normalisation, header aliasing, email/mobile rules, username derivation) were exercised directly against edge cases — quoted fields with commas, escaped quotes, BOM, blank lines, `K22`/`2022`/junk batches.
- **The frontend build was not run.** `node_modules` is absent and `npm install` had no network in my environment, so `vite build` never executed. The JSX is reviewed but not compiler-verified — please run `npm install && npm run build` in `frontend/` before merging.

## Config

Mail sending uses the existing `AUTH_EMAIL` / `AUTH_PASSWORD`. New optional vars documented in `.env.example`: `CLIENT_URL` (login link, falls back to `CORS_ORIGIN`), `ONBOARDING_MAIL_LIMIT`, `ONBOARDING_MAIL_WINDOW_HOURS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
