### PR TITLE
Add Google Sign-In and fix OTP delivery/verification bugs

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,6 +24,13 @@ CLIENT_URL=http://localhost:5173
 ONBOARDING_MAIL_LIMIT=100
 ONBOARDING_MAIL_WINDOW_HOURS=24
 
+# Google Sign-In
+# OAuth 2.0 Web client ID from https://console.cloud.google.com/apis/credentials
+# The SAME value must be set as VITE_GOOGLE_CLIENT_ID in the frontend.
+GOOGLE_CLIENT_ID=xxxxxxxxxxxx.apps.googleusercontent.com
+# Comma separated domains allowed to sign in. Empty disables the check.
+GOOGLE_ALLOWED_DOMAINS=bitmesra.ac.in
+
 # Cloudinary (for file uploads)
 CLOUDINARY_CLOUD_NAME=your-cloud-name
 CLOUDINARY_API_KEY=your-api-key

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.21.0",
         "express-rate-limit": "^7.5.0",
+        "google-auth-library": "^11.0.1",
         "http": "^0.0.1-security",
         "jsonwebtoken": "^9.0.2",
         "moment": "^2.30.1",
@@ -204,6 +205,26 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/base64id": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
@@ -224,6 +245,15 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -505,6 +535,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -759,6 +798,35 @@
         "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -787,6 +855,18 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -876,6 +956,83 @@
         "node": ">=10"
       }
     },
+    "node_modules/gaxios": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gaxios/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/gaxios/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/gaxios/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -924,6 +1081,67 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.1.tgz",
+      "integrity": "sha512-ZqfaYduu9ASUaFuUk5dF9g9QvufdhhSj7jFiEnCrTQcH57sFPKYetM0iU4dcKkQk6CqC1xpSrVr5uQ9NhqjNOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "^9.0.0",
+        "google-logging-utils": "^2.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gcp-metadata": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-9.0.2.tgz",
+      "integrity": "sha512-zzoIz7qKIxyDp7Zghb12kl+n5Y1ofqYX97O/5MelKuFuDolvmT9RuIBGpEnHjqS4GBzPgMZFqH+WSUafRkn5dQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.1.3",
+        "google-logging-utils": "^2.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-2.0.1.tgz",
+      "integrity": "sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/gopd": {
@@ -1149,6 +1367,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
@@ -1615,6 +1842,26 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -2446,6 +2693,15 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,7 +16,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.21.0",
         "express-rate-limit": "^7.5.0",
-        "google-auth-library": "^11.0.1",
+        "google-auth-library": "^10.9.1",
         "http": "^0.0.1-security",
         "jsonwebtoken": "^9.0.2",
         "moment": "^2.30.1",
@@ -1084,34 +1084,34 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.1.tgz",
-      "integrity": "sha512-ZqfaYduu9ASUaFuUk5dF9g9QvufdhhSj7jFiEnCrTQcH57sFPKYetM0iU4dcKkQk6CqC1xpSrVr5uQ9NhqjNOg==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
         "gaxios": "^7.1.4",
-        "gcp-metadata": "^9.0.0",
-        "google-logging-utils": "^2.0.0",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/google-auth-library/node_modules/gcp-metadata": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-9.0.2.tgz",
-      "integrity": "sha512-zzoIz7qKIxyDp7Zghb12kl+n5Y1ofqYX97O/5MelKuFuDolvmT9RuIBGpEnHjqS4GBzPgMZFqH+WSUafRkn5dQ==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "gaxios": "^7.1.3",
-        "google-logging-utils": "^2.0.0",
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/google-auth-library/node_modules/jwa": {
@@ -1136,12 +1136,12 @@
       }
     },
     "node_modules/google-logging-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-2.0.1.tgz",
-      "integrity": "sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=22"
+        "node": ">=14"
       }
     },
     "node_modules/gopd": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
     "dev": "nodemon -r dotenv/config --experimental-json-modules src/index.js",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prod":"node -r dotenv/config --experimental-json-modules src/index.js"
+    "prod": "node -r dotenv/config --experimental-json-modules src/index.js"
   },
   "author": "",
   "license": "ISC",
@@ -21,6 +21,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.21.0",
     "express-rate-limit": "^7.5.0",
+    "google-auth-library": "^11.0.1",
     "http": "^0.0.1-security",
     "jsonwebtoken": "^9.0.2",
     "moment": "^2.30.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,7 +21,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.21.0",
     "express-rate-limit": "^7.5.0",
-    "google-auth-library": "^11.0.1",
+    "google-auth-library": "^10.9.1",
     "http": "^0.0.1-security",
     "jsonwebtoken": "^9.0.2",
     "moment": "^2.30.1",

--- a/backend/src/controllers/professor.controller.js
+++ b/backend/src/controllers/professor.controller.js
@@ -946,9 +946,10 @@ const otpForgotPassword = asyncHandler(async (req, res) => {
     throw new ApiError(404, "Professor does not exists");
   }
   const otp = `${Math.floor(Math.random() * 9000 + 1000)}`;
+  // Keep a single live OTP per email so every code path agrees on the current one.
+  await Otp.deleteMany({ email });
   await Otp.create({ email, otp });
 
-  const tOtp = await Otp.findOne({ email });
   const transporter = nodemailer.createTransport({
     service: "gmail",
     auth: {
@@ -1011,7 +1012,7 @@ const otpForgotPassword = asyncHandler(async (req, res) => {
             <div class="content">
               <p>Hello,</p>
               <p>Thank you for choosing BITAcademia. To reset your password, please use the following One-Time Password (OTP):</p>
-              <p class="otp">${tOtp.otp}</p>
+              <p class="otp">${otp}</p>
               <p>If you did not request this OTP, please ignore this email or contact our support team.</p>
               <p>Best regards,</p>
               <p>TEAM BITACADEMIA</p>
@@ -1025,13 +1026,16 @@ const otpForgotPassword = asyncHandler(async (req, res) => {
       `,
   };
 
-  transporter.sendMail(mailOptions, async (error) => {
-    if (error) {
-      console.log("Error sending email to:", email, error);
-    } else {
-      console.log("Email sent to:", email);
-    }
-  });
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log("Email sent to:", email);
+  } catch (error) {
+    console.log("Error sending email to:", email, error.message);
+    await Otp.deleteMany({ email });
+    return res.status(502).json({
+      message: "Could not send the OTP email. Please try again in a few minutes.",
+    });
+  }
   res.status(200).send("Mail sent!");
 });
 

--- a/backend/src/controllers/user.controller.js
+++ b/backend/src/controllers/user.controller.js
@@ -1,4 +1,5 @@
 import bcrypt from "bcrypt";
+import { OAuth2Client } from "google-auth-library";
 import cron from "node-cron";
 import { Otp } from "../models/otp.model.js";
 import { Placement } from "../models/placement.model.js";
@@ -35,10 +36,17 @@ const verifyMail = asyncHandler(async (req, res) => {
     if (existedUser) {
       throw new ApiError(409, "User with email/username already exists");
     }
+    await Otp.deleteMany({ email });
     await Otp.create({ email, otp });
 
     // Send OTP email using utility function
-    await sendOTP(email, otp, "verification");
+    const sent = await sendOTP(email, otp, "verification");
+    if (!sent) {
+      await Otp.deleteMany({ email });
+      return res.status(502).json({
+        message: "Could not send the OTP email. Please try again in a few minutes.",
+      });
+    }
 
     res.status(200).send("Mail sent!");
   } catch (error) {
@@ -50,7 +58,7 @@ const verifyMail = asyncHandler(async (req, res) => {
 const registerUser = asyncHandler(async (req, res) => {
   const { username, password, fullName, rollNumber, email, usrOTP, batch } =
     req.body;
-  const otpEntry = await Otp.findOne({ email });
+  const otpEntry = await Otp.findOne({ email }).sort({ createdAt: -1 });
 
   if (!otpEntry || usrOTP.toString() !== otpEntry.otp.toString()) {
     console.log("Invalid OTP:", usrOTP, otpEntry.otp);
@@ -61,7 +69,7 @@ const registerUser = asyncHandler(async (req, res) => {
     // throw new ApiError(400, "wrong otp, validation failed");
   }
 
-  await Otp.deleteOne({ email });
+  await Otp.deleteMany({ email });
 
   // Validate required string fields
   const stringFields = [username, password, fullName, rollNumber, email];
@@ -219,6 +227,109 @@ const loginUser = asyncHandler(async (req, res) => {
     );
 });
 
+const googleClient = new OAuth2Client();
+
+/**
+ * Google accounts must belong to one of these domains to sign in.
+ * Comma separated, e.g. "bitmesra.ac.in,alumni.bitmesra.ac.in".
+ * An empty value disables the domain check.
+ */
+const allowedGoogleDomains = () =>
+  (process.env.GOOGLE_ALLOWED_DOMAINS ?? "bitmesra.ac.in")
+    .split(",")
+    .map((d) => d.trim().toLowerCase())
+    .filter(Boolean);
+
+/**
+ * Signs a user in from a Google Identity Services ID token.
+ * The account must already exist - registration still goes through /register,
+ * since we need the roll number, batch and ID card that Google can't give us.
+ */
+const googleLogin = asyncHandler(async (req, res) => {
+  const { credential } = req.body;
+  if (!credential) {
+    return res
+      .status(400)
+      .json({ success: false, message: "Missing Google credential" });
+  }
+
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  if (!clientId) {
+    console.log("GOOGLE_CLIENT_ID is not set - Google sign-in is disabled");
+    return res
+      .status(500)
+      .json({ success: false, message: "Google sign-in is not configured" });
+  }
+
+  // Verifies signature, issuer, audience and expiry. Throws on any mismatch.
+  let payload;
+  try {
+    const ticket = await googleClient.verifyIdToken({
+      idToken: credential,
+      audience: clientId,
+    });
+    payload = ticket.getPayload();
+  } catch (error) {
+    console.log("Google token verification failed:", error.message);
+    return res
+      .status(401)
+      .json({ success: false, message: "Google sign-in failed. Please try again." });
+  }
+
+  const email = (payload?.email || "").toLowerCase();
+  if (!email || !payload.email_verified) {
+    return res.status(401).json({
+      success: false,
+      message: "This Google account has no verified email address",
+    });
+  }
+
+  const domains = allowedGoogleDomains();
+  if (domains.length && !domains.some((d) => email.endsWith(`@${d}`))) {
+    return res.status(403).json({
+      success: false,
+      message: `Please sign in with your @${domains[0]} account.`,
+    });
+  }
+
+  const user = await User.findOne({ email });
+  if (!user) {
+    console.log("Google sign-in for unknown account:", email);
+    return res.status(404).json({
+      success: false,
+      message: "No BITAcademia account exists for this email. Please sign up first.",
+    });
+  }
+
+  if (!user.isVerified) {
+    return res
+      .status(403)
+      .json({ success: false, message: "You are not verified yet!" });
+  }
+
+  const { accessToken, refreshToken } = await generateAcessAndRefreshToken(
+    user._id
+  );
+  const loggedInUser = await User.findById(user._id).select(
+    "-password -refreshToken"
+  );
+  const options = {
+    httpOnly: true,
+    secure: false,
+  };
+  return res
+    .status(200)
+    .cookie("accessToken", accessToken, options)
+    .cookie("refreshToken", refreshToken, options)
+    .json(
+      new ApiResponse(
+        200,
+        { user: loggedInUser, accessToken, refreshToken },
+        "User loggedIn successfully!"
+      )
+    );
+});
+
 export const otpForgotPass = asyncHandler(async (req, res) => {
   try {
     const { email } = req.body;
@@ -231,10 +342,19 @@ export const otpForgotPass = asyncHandler(async (req, res) => {
       throw new ApiError(404, "User does not exists");
     }
     const otp = `${Math.floor(Math.random() * 9000 + 1000)}`;
+    // Only ever keep one live OTP per email, so every code path agrees on
+    // which one is current.
+    await Otp.deleteMany({ email });
     await Otp.create({ email, otp });
 
     // Send OTP email using utility function
-    await sendOTP(email, otp, "forgot-password");
+    const sent = await sendOTP(email, otp, "forgot-password");
+    if (!sent) {
+      await Otp.deleteMany({ email });
+      return res.status(502).json({
+        message: "Could not send the OTP email. Please try again in a few minutes.",
+      });
+    }
 
     res.status(200).send("Mail sent!");
   } catch (error) {
@@ -254,7 +374,8 @@ const changepassword = asyncHandler(async (req, res) => {
     const user = await User.findOne({ email });
     if (!user) throw new ApiError(404, "User not found");
 
-    const otpverify = await Otp.find({ email });
+    // sorted oldest-first so the pop() below always yields the newest OTP
+    const otpverify = await Otp.find({ email }).sort({ createdAt: 1 });
     if (otpverify.length === 0) {
       throw new ApiError(
         400,
@@ -263,10 +384,7 @@ const changepassword = asyncHandler(async (req, res) => {
     }
 
     const hashedOTP = otpverify.pop().otp;
-    console.log(otp);
-    console.log(hashedOTP);
     const validOTP = otp === hashedOTP;
-    console.log(validOTP);
 
     if (!validOTP) {
       throw new ApiError(400, "Invalid OTP. Check your inbox.");
@@ -897,6 +1015,7 @@ export {
   getPlacementThree,
   getPlacementTwo,
   getUserbyRoll,
+  googleLogin,
   loginUser,
   logoutUser,
   registerUser,

--- a/backend/src/models/otp.model.js
+++ b/backend/src/models/otp.model.js
@@ -1,18 +1,24 @@
 import mongoose, { Schema } from "mongoose";
 import { User } from "./user.model.js";
 
-const otpSchema = new Schema({
-  email: {
-    type: String,
-    ref: "User",
-    required: true,
-    lowercase: true,
-    trim: true,
+// timestamps must stay on: the collection has a TTL index on createdAt
+// (expireAfterSeconds: 600). Without the field Mongo can never expire a
+// document, so OTPs pile up forever.
+const otpSchema = new Schema(
+  {
+    email: {
+      type: String,
+      ref: "User",
+      required: true,
+      lowercase: true,
+      trim: true,
+    },
+    otp: {
+      type: String,
+      required: true,
+    },
   },
-  otp: {
-    type: String,
-    required: true,
-  },
-});
+  { timestamps: true }
+);
 
 export const Otp = mongoose.model("Otp", otpSchema);

--- a/backend/src/routes/user.routes.js
+++ b/backend/src/routes/user.routes.js
@@ -3,6 +3,7 @@ import { verifyProfessor } from "../middlewares/auth.middleware.js";
 import {
   registerUser,
   loginUser,
+  googleLogin,
   logoutUser,
   updateUser1,
   updatePlacementOne,
@@ -46,6 +47,14 @@ router
   .post(upload.fields([{ name: "idCard", maxCount: 1 }]), registerUser);
 
 router.route("/login").post(loginUser);
+
+const googleLoginLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  max: 20,
+});
+router
+  .route("/google-login")
+  .post(requestIpMiddleware, googleLoginLimiter, googleLogin);
 router.route("/logout").post(verifyJWT, logoutUser);
 router.route("/update").patch(
   verifyJWT,
@@ -86,7 +95,13 @@ router.route("/placementTwo").get(verifyJWT, getPlacementTwo);
 router.route("/placementThree").get(verifyJWT, getPlacementThree);
 router.route("/get-all-users").get(verifyAdmin, getAllUsers);
 router.route("/get-backlogs").get(verifyJWT, getAllBacklogSubjects);
-router.route("/get-pass-otp").post(otpForgotPass);
+const otpRequestLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  max: 3,
+});
+router
+  .route("/get-pass-otp")
+  .post(requestIpMiddleware, otpRequestLimiter, otpForgotPass);
 const changePassLimiter = createRateLimiter({
   windowMs: 15 * 60 * 1000,
   max: 5,

--- a/backend/src/routes/user.routes.js
+++ b/backend/src/routes/user.routes.js
@@ -46,7 +46,13 @@ router
   .route("/register")
   .post(upload.fields([{ name: "idCard", maxCount: 1 }]), registerUser);
 
-router.route("/login").post(loginUser);
+// Password login is brute-forceable once the app is reachable from the
+// internet, so cap attempts per IP.
+const loginLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+});
+router.route("/login").post(requestIpMiddleware, loginLimiter, loginUser);
 
 const googleLoginLimiter = createRateLimiter({
   windowMs: 15 * 60 * 1000,

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+# OAuth 2.0 Web client ID from https://console.cloud.google.com/apis/credentials
+# Must match GOOGLE_CLIENT_ID in backend/.env
+# Leave unset to hide the "Sign in with Google" button entirely.
+VITE_GOOGLE_CLIENT_ID=xxxxxxxxxxxx.apps.googleusercontent.com

--- a/frontend/src/components/GoogleSignInButton.jsx
+++ b/frontend/src/components/GoogleSignInButton.jsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useRef, useState } from "react";
+
+const GIS_SRC = "https://accounts.google.com/gsi/client";
+
+/**
+ * Renders Google's official "Sign in with Google" button.
+ *
+ * Calls onCredential(idToken) once the user picks an account. The token is
+ * verified server side by POST /api/v1/users/google-login - nothing here is
+ * trusted on its own.
+ *
+ * Renders nothing when VITE_GOOGLE_CLIENT_ID is unset, so the login page keeps
+ * working normally on deployments where Google sign-in isn't configured yet.
+ */
+export default function GoogleSignInButton({ onCredential, disabled = false }) {
+  const holder = useRef(null);
+  const callbackRef = useRef(onCredential);
+  const [loadError, setLoadError] = useState("");
+  const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+
+  // Keep the newest callback without re-initialising Google's script.
+  useEffect(() => {
+    callbackRef.current = onCredential;
+  }, [onCredential]);
+
+  useEffect(() => {
+    if (!clientId) return undefined;
+    let cancelled = false;
+
+    const renderButton = () => {
+      if (cancelled || !window.google?.accounts?.id || !holder.current) return;
+      window.google.accounts.id.initialize({
+        client_id: clientId,
+        callback: (response) => callbackRef.current?.(response.credential),
+        cancel_on_tap_outside: true,
+      });
+      holder.current.innerHTML = "";
+      window.google.accounts.id.renderButton(holder.current, {
+        theme: "outline",
+        size: "large",
+        text: "signin_with",
+        shape: "rectangular",
+        logo_alignment: "center",
+        width: 360,
+      });
+    };
+
+    const existing = document.querySelector(`script[src="${GIS_SRC}"]`);
+    if (existing) {
+      if (window.google?.accounts?.id) renderButton();
+      else existing.addEventListener("load", renderButton);
+      return () => {
+        cancelled = true;
+        existing.removeEventListener("load", renderButton);
+      };
+    }
+
+    const script = document.createElement("script");
+    script.src = GIS_SRC;
+    script.async = true;
+    script.defer = true;
+    script.onload = renderButton;
+    script.onerror = () =>
+      setLoadError("Could not load Google sign-in. Check your connection.");
+    document.body.appendChild(script);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [clientId]);
+
+  if (!clientId) return null;
+
+  return (
+    <div className="w-full flex flex-col items-center">
+      <div className="w-full flex items-center gap-3 my-4">
+        <span className="h-px flex-1 bg-gray-300" />
+        <span className="text-xs uppercase tracking-wide text-gray-500">or</span>
+        <span className="h-px flex-1 bg-gray-300" />
+      </div>
+      <div
+        ref={holder}
+        className={
+          disabled ? "opacity-50 pointer-events-none" : undefined
+        }
+      />
+      {loadError && (
+        <p className="mt-2 text-xs text-red-600">{loadError}</p>
+      )}
+      <p className="mt-2 text-xs text-gray-500 text-center">
+        Use your @bitmesra.ac.in account - no password or OTP needed.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -4,6 +4,7 @@ import axios from "axios";
 import { toast, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import NavBar from "./NavBar";
+import GoogleSignInButton from "./GoogleSignInButton";
 import { useEffect } from "react";
 
 export default function Login() {
@@ -70,6 +71,26 @@ export default function Login() {
       // }
       let errorMessage = error.response.data.message;
       toast.error(errorMessage || "Error occurred during login");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleGoogleCredential = async (credential) => {
+    setIsLoading(true);
+    try {
+      const response = await axios.post("/api/v1/users/google-login", {
+        credential,
+      });
+      localStorage.setItem("user", JSON.stringify(response.data.data.user));
+      toast.success("Login successful!");
+      setTimeout(() => {
+        navigate("/db");
+      }, 1500);
+    } catch (error) {
+      toast.error(
+        error.response?.data?.message || "Google sign-in failed. Please try again."
+      );
     } finally {
       setIsLoading(false);
     }
@@ -189,6 +210,11 @@ export default function Login() {
                   )}
                 </button>
               </div>
+
+              <GoogleSignInButton
+                onCredential={handleGoogleCredential}
+                disabled={isLoading}
+              />
 
               <div className="w-full border-t pt-2 mt-2">
                 <p className="text-sm text-gray-600 mb-2">Helpful Resources:</p>

--- a/frontend/src/components/forgot-password.jsx
+++ b/frontend/src/components/forgot-password.jsx
@@ -21,7 +21,16 @@ export default function ForgotPassword() {
       toast.success("OTP sent to your email address.");
       setOtpSent(true);
     } catch (error) {
-      toast.error("Failed to send OTP. Please check your email.");
+      if (error.response?.status === 429) {
+        toast.error(
+          "Too many OTP requests. Please wait 15 minutes before trying again."
+        );
+      } else {
+        toast.error(
+          error.response?.data?.message ||
+            "Failed to send OTP. Please check your email."
+        );
+      }
     } finally {
       setLoading(false);
     }
@@ -50,7 +59,10 @@ export default function ForgotPassword() {
         navigate("/log");
       }, 2000);
     } catch (error) {
-      toast.error("Failed to reset password. Please try again.");
+      toast.error(
+        error.response?.data?.message ||
+          "Failed to reset password. Please try again."
+      );
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Why

Students reported the forgot-password flow saying *"OTP sent to your email address"* while no email arrived. Investigation on the server showed the app could not tell a successful send from a failed one, plus several bugs that made OTPs fail even when the mail did arrive.

Google Sign-In is added as the durable fix: students all have `@bitmesra.ac.in` Google Workspace accounts, so login no longer depends on email delivery at all.

## Google Sign-In

New endpoint `POST /api/v1/users/google-login`, rate limited to 20 req / 15 min per IP.

- Verifies the Google ID token server side via `google-auth-library` (signature, issuer, audience, expiry) and requires `email_verified`
- Restricts sign-in to `GOOGLE_ALLOWED_DOMAINS` (default `bitmesra.ac.in`)
- Issues the **same** cookies and tokens as password login, so the client handles both paths identically
- **Does not auto-create accounts** — the schema requires `rollNumber`, `batch` and `idCard`, which Google cannot supply. Unknown emails get a clear "please sign up first" message.
- `GoogleSignInButton` renders **nothing** when `VITE_GOOGLE_CLIENT_ID` is unset, so this is completely inert until configured

## OTP fixes

| Bug | Fix |
|---|---|
| TTL index on `createdAt` existed, but the schema never wrote that field — **0 of 610 rows could ever expire** (oldest alive since Mar 2025) | `{ timestamps: true }` on `otpSchema` |
| Multiple OTPs accumulated per email and different code paths picked different ones | `deleteMany` before every create — one live OTP per email |
| `sendOTP` returned `false` on failure and the controller ignored it, always replying `"Mail sent!"` | Return **502** with a real message and roll back the OTP row |
| `/get-pass-otp` was unthrottled — one student pulled 24 OTPs in a day | 3 requests / 15 min per IP |

### Two further bugs found while fixing the above

- **Professor reset emailed the wrong code.** `professor.controller.js` created an OTP then read it back with `Otp.findOne({ email })`, which returns the *oldest* row, while `changepassword` validates the *newest*. Any professor who requested twice received a code that could never validate — a guaranteed lockout independent of email delivery.
- **`registerUser` had the same ordering bug** — now sorts newest-first; `deleteOne` → `deleteMany`.

Also removed three `console.log` calls writing plaintext OTP codes into `dev.log`, and the forgot-password UI now surfaces real server errors instead of a blanket failure message.

## Config required before Google Sign-In activates

```bash
# backend/.env
GOOGLE_CLIENT_ID=xxxx.apps.googleusercontent.com
GOOGLE_ALLOWED_DOMAINS=bitmesra.ac.in
CORS_ORIGIN=https://<your-domain>     # currently localhost:5173

# frontend/.env
VITE_GOOGLE_CLIENT_ID=xxxx.apps.googleusercontent.com
```

Google requires an **HTTPS origin on a real domain** — raw IPs are rejected, only `localhost` is exempt. Register the origin under *Authorized JavaScript origins*; no redirect URI is needed for this flow. Note Vite inlines `VITE_*` at build time, so the frontend must be rebuilt after setting it.

## Follow-up not in this PR

610 existing OTP rows predate `createdAt`, so the TTL still cannot reach them. One-time sweep:

```js
db.otps.deleteMany({ createdAt: { $exists: false } })
```

## Testing

Backend files pass `node --check`; frontend files compile via esbuild. Google sign-in end-to-end needs the client ID and an HTTPS origin, so it has not been exercised against live Google yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JefK4aw1Cpqjg1oP4aPsa