### PR TITLE
Open Minor Project registration to batch K22

### DIFF
--- a/backend/src/controllers/minor.controller.js
+++ b/backend/src/controllers/minor.controller.js
@@ -5,13 +5,17 @@ import { User } from "../models/user.model.js";
 import { Minor } from "../models/minor.model.js";
 import { customAlphabet, nanoid } from "nanoid";
 import { Professor } from "../models/professor.model.js";
+import {
+  isMinorBatchAllowed,
+  MINOR_BATCHES_LABEL,
+} from "../utils/projectEligibility.js";
 
 const createGroup = asyncHandler(async (req, res) => {
   const leader = req?.user?._id;
-  if (req.user.batch !== 23) {
+  if (!isMinorBatchAllowed(req.user.batch)) {
     return res.status(403).json({
       success: false,
-      message: `Registration for Minor Project is currently open for batch K23 only. Process not started for batch K${req.user.batch}.`,
+      message: `Registration for Minor Project is currently open for batch ${MINOR_BATCHES_LABEL} only. Process not started for batch K${req.user.batch}.`,
     });
   }
   const nanoid = customAlphabet("ABCDEFGHJKLMNPQRSTUVWXYZ23456789", 6);
@@ -75,10 +79,10 @@ const addMember = asyncHandler(async (req, res) => {
   const loggedIn = req?.user?._id;
   const { rollNumber, groupId } = req.body;
 
-  if (req.user.batch !== 23) {
+  if (!isMinorBatchAllowed(req.user.batch)) {
     return res.status(403).json({
       success: false,
-      message: `Registration for Minor Project is currently open for batch K23 only. Process not started for batch K${req.user.batch}.`,
+      message: `Registration for Minor Project is currently open for batch ${MINOR_BATCHES_LABEL} only. Process not started for batch K${req.user.batch}.`,
     });
   }
 
@@ -266,10 +270,10 @@ const applyToFaculty = asyncHandler(async (req, res) => {
   const { facultyId } = req.body;
   const userId = req?.user?._id;
 
-  if (req.user.batch !== 23) {
+  if (!isMinorBatchAllowed(req.user.batch)) {
     return res.status(403).json({
       success: false,
-      message: `Registration for Minor Project is currently open for batch K23 only. Process not started for batch K${req.user.batch}.`,
+      message: `Registration for Minor Project is currently open for batch ${MINOR_BATCHES_LABEL} only. Process not started for batch K${req.user.batch}.`,
     });
   }
 

--- a/backend/src/utils/projectEligibility.js
+++ b/backend/src/utils/projectEligibility.js
@@ -1,0 +1,14 @@
+// Batches for which Minor Project registration is currently open.
+// Update this list at the start of a session instead of editing controllers.
+export const MINOR_PROJECT_BATCHES = [22, 23];
+
+export const formatBatches = (batches) => {
+  const labels = batches.map((batch) => `K${batch}`);
+  if (labels.length < 2) return labels.join("");
+  return `${labels.slice(0, -1).join(", ")} and ${labels[labels.length - 1]}`;
+};
+
+export const isMinorBatchAllowed = (batch) =>
+  MINOR_PROJECT_BATCHES.includes(Number(batch));
+
+export const MINOR_BATCHES_LABEL = formatBatches(MINOR_PROJECT_BATCHES);

--- a/frontend/src/components/MinorGroupManagement.jsx
+++ b/frontend/src/components/MinorGroupManagement.jsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
 import { toast, Toaster } from "react-hot-toast";
+import {
+  isMinorBatchAllowed,
+  MINOR_BATCHES_LABEL,
+} from "../utils/projectEligibility";
 
 const handleError = (error, defaultMessage) => {
   let message = error.response.data.message;
@@ -60,8 +64,8 @@ const MinorGroupManagement = () => {
   }, []);
 
   useEffect(() => {
-    if (currentUser && !currentUser.isMinorAllocated && currentUser.batch !== 23) {
-      toast.error(`Registration for Minor Project is open for batch K23 only. Process not started for batch K${currentUser.batch}.`, {
+    if (currentUser && !currentUser.isMinorAllocated && !isMinorBatchAllowed(currentUser.batch)) {
+      toast.error(`Registration for Minor Project is open for batch ${MINOR_BATCHES_LABEL} only. Process not started for batch K${currentUser.batch}.`, {
         id: "group-batch-error-toast",
       });
     }
@@ -161,7 +165,7 @@ const MinorGroupManagement = () => {
     );
   }
 
-  if (currentUser && !currentUser.isMinorAllocated && currentUser.batch !== 23) {
+  if (currentUser && !currentUser.isMinorAllocated && !isMinorBatchAllowed(currentUser.batch)) {
     return (
       <>
         <Toaster position="top-right" />
@@ -176,7 +180,7 @@ const MinorGroupManagement = () => {
               Process Not Started
             </h1>
             <p className="text-gray-600 mb-6 leading-relaxed">
-              Registration for Minor Project is currently open for batch <strong className="text-blue-600 font-semibold">K23</strong> only.
+              Registration for Minor Project is currently open for batch <strong className="text-blue-600 font-semibold">{MINOR_BATCHES_LABEL}</strong> only.
             </p>
             <div className="bg-gray-50/50 backdrop-blur-sm rounded-xl p-5 mb-2 inline-block w-full border border-gray-200/60 shadow-inner">
               <p className="text-sm text-gray-700">

--- a/frontend/src/components/MinorProject.jsx
+++ b/frontend/src/components/MinorProject.jsx
@@ -3,6 +3,10 @@ import axios from "axios";
 import Swal from "sweetalert2";
 import { toast, Toaster } from "react-hot-toast";
 import ChatBox from "./ChatBox";
+import {
+  isMinorBatchAllowed,
+  MINOR_BATCHES_LABEL,
+} from "../utils/projectEligibility";
 
 const handleError = (error, defaultMessage) => {
 
@@ -109,8 +113,8 @@ const MinorProject = () => {
   }, [currentUser]);
 
   useEffect(() => {
-    if (currentUser && !currentUser.isMinorAllocated && !allocatedProf && currentUser.batch !== 23) {
-      toast.error(`Registration for Minor Project is open for batch K23 only. Process not started for batch K${currentUser.batch}.`, {
+    if (currentUser && !currentUser.isMinorAllocated && !allocatedProf && !isMinorBatchAllowed(currentUser.batch)) {
+      toast.error(`Registration for Minor Project is open for batch ${MINOR_BATCHES_LABEL} only. Process not started for batch K${currentUser.batch}.`, {
         id: "batch-error-toast",
       });
     }
@@ -253,7 +257,7 @@ const MinorProject = () => {
     );
   }
 
-  if (currentUser && !currentUser.isMinorAllocated && !allocatedProf && currentUser.batch !== 23) {
+  if (currentUser && !currentUser.isMinorAllocated && !allocatedProf && !isMinorBatchAllowed(currentUser.batch)) {
     return (
       <>
         <Toaster position="top-right" />
@@ -268,7 +272,7 @@ const MinorProject = () => {
               Process Not Started
             </h1>
             <p className="text-gray-600 mb-6 leading-relaxed">
-              Registration for Minor Project is currently open for batch <strong className="text-blue-600 font-semibold">K23</strong> only.
+              Registration for Minor Project is currently open for batch <strong className="text-blue-600 font-semibold">{MINOR_BATCHES_LABEL}</strong> only.
             </p>
             <div className="bg-gray-50/50 backdrop-blur-sm rounded-xl p-5 mb-2 inline-block w-full border border-gray-200/60 shadow-inner">
               <p className="text-sm text-gray-700">

--- a/frontend/src/utils/projectEligibility.js
+++ b/frontend/src/utils/projectEligibility.js
@@ -1,0 +1,14 @@
+// Batches for which Minor Project registration is currently open.
+// Update this list at the start of a session instead of editing controllers.
+export const MINOR_PROJECT_BATCHES = [22, 23];
+
+export const formatBatches = (batches) => {
+  const labels = batches.map((batch) => `K${batch}`);
+  if (labels.length < 2) return labels.join("");
+  return `${labels.slice(0, -1).join(", ")} and ${labels[labels.length - 1]}`;
+};
+
+export const isMinorBatchAllowed = (batch) =>
+  MINOR_PROJECT_BATCHES.includes(Number(batch));
+
+export const MINOR_BATCHES_LABEL = formatBatches(MINOR_PROJECT_BATCHES);


### PR DESCRIPTION
## Problem

K22 students (7th sem) cannot apply to Minor Project. The eligible batch is hardcoded as `23` in seven places, so K22 gets a 403 from the API and the **Process Not Started** screen in the UI:

- `backend/src/controllers/minor.controller.js` — `createGroup`, `addMember`, `applyToFaculty`
- `frontend/src/components/MinorProject.jsx` — toast + full-page guard
- `frontend/src/components/MinorGroupManagement.jsx` — toast + full-page guard

The pins were set in 38eb2e5 (Major → K22, Minor → K23) for the previous session.

## Change

Adds `utils/projectEligibility.js` on both sides — mirrored the same way `studentYear.js` already is — exporting `MINOR_PROJECT_BATCHES = [22, 23]`, `isMinorBatchAllowed()` and `MINOR_BATCHES_LABEL` ("K22 and K23"). All seven call sites now read from it, and the user-facing copy renders the batch list instead of a literal "K23".

K23 keeps access, so in-flight K23 groups and pending faculty applications are unaffected. Major Project is untouched, still pinned to K22.

Next session's rollover becomes a one-line edit in the two util files.

## Verification

- `backend/src/controllers/minor.controller.js` parses clean as ESM.
- Helper returns `true` for `22` and `"23"`, `false` for `24` (batch is a Number in the model; `Number()` coercion covers string inputs).
- No literal `batch !== 23` checks remain in `backend/src` or `frontend/src`.
- Frontend not compiler-checked — `frontend/node_modules` isn't installed locally, so the JSX changes are diff-reviewed only.

## Note for whoever runs the allocation

Professor capacity is a single global pool per faculty — `limits.minor_project` (default 6) with one `currentCount.minor_project`, no per-batch split. With both batches eligible at once, K22 and K23 compete for the same seats. Limits may need raising via the admin Increase Limit page or `backend/scripts/increment_limit.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)